### PR TITLE
Add scenario selection, telemetry, and world improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,36 @@ Playwright. The game itself does not need it.
 | W A S D | Move |
 | Shift | Sprint |
 | Space | Jump |
+| Esc | Pause; resume, change scenario or exit to the start menu |
 | 1 - 5 | Teleport along the trail |
 
 The teleport keys are 1 trailhead, 2 mid trail, 3 ruins approach, 4 temple
 clearing, 5 the falls.
+
+During play the upper-left panel reports FPS and CPU/GPU frame load. GPU is
+shown as `n/d` when the browser does not expose a WebGL timer query.
+
+## Scenarios
+
+The same world-builder spine serves more than one biome. Opening the app without
+a scenario hash shows a picker for the original jungle and the temperate autumn
+forest. The choice can also be deep-linked by appending a hash:
+
+```
+#forest            → the autumn forest
+#scenario=forest   → same thing, spelled out
+#scenario=forest&tier=low   → forest at the low quality tier
+```
+
+Each scenario in `src/scenario.js` swaps the authored layers that make a
+biome: the ground surfaces that bake, the leaf-atlas palette, the vegetation
+weights, the atmosphere (fog, hemisphere light, sun) and the audio score. The
+jungle entry preserves the original tuning and default output; the capture
+tools drive the same hash, so
+`#scenario=forest&manual` is the deterministic way to point the harness at
+the forest. Offline audio renders accept the same choice explicitly, for
+example `node tools/audio.mjs mix --scenario forest`; forest WAVs get a
+`-forest` suffix so they cannot overwrite the jungle references.
 
 ![Mid trail](media/02-mid-trail.jpg)
 

--- a/index.html
+++ b/index.html
@@ -7,14 +7,145 @@
 <style>
   :root { color-scheme: dark; }
   html, body { margin: 0; height: 100%; overflow: hidden; background: #05070a; }
-  /* The canvas is the entire experience — no HUD, no overlay, nothing that
-     would remind you it is a program. */
+  /* The canvas is the gameplay surface; menus are explicit overlays above it. */
   #view { display: block; width: 100vw; height: 100vh; }
+  #telemetry {
+    position: fixed; top: 16px; left: 16px; z-index: 5;
+    width: min(224px, calc(100vw - 32px)); padding: 11px 12px 10px;
+    box-sizing: border-box; border: 1px solid rgba(202, 221, 193, .18);
+    border-radius: 4px; color: #e9eee5; background: rgba(7, 13, 9, .72);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, .20); backdrop-filter: blur(5px);
+    font: 400 11px/1.35 ui-sans-serif, system-ui, sans-serif;
+    letter-spacing: .08em; pointer-events: none;
+  }
+  #telemetry[hidden] { display: none; }
+  .telemetry-metrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .telemetry-metric { display: grid; gap: 2px; min-width: 0; }
+  .telemetry-metric span { color: #8f9f89; font-size: 9px; letter-spacing: .14em; }
+  .telemetry-metric strong { color: #e9eee5; font-size: 14px; font-weight: 500; letter-spacing: .02em; }
+  .telemetry-divider { height: 1px; margin: 10px 0 9px; background: rgba(202, 221, 193, .14); }
+  .teleport-heading { display: flex; justify-content: space-between; gap: 8px; color: #a2b596; font-size: 9px; letter-spacing: .16em; text-transform: uppercase; }
+  .teleport-heading span:last-child { color: #71806c; letter-spacing: .08em; text-transform: none; }
+  .teleport-list { display: grid; gap: 4px; margin-top: 7px; }
+  .teleport-button {
+    display: grid; grid-template-columns: 21px minmax(0, 1fr); align-items: center;
+    gap: 7px; width: 100%; min-height: 26px; padding: 3px 5px;
+    border: 1px solid transparent; border-radius: 3px; color: #cbd5c5;
+    background: transparent; cursor: pointer; text-align: left;
+    font: inherit; letter-spacing: .02em; pointer-events: auto;
+    transition: border-color .16s, background .16s, color .16s;
+  }
+  .teleport-button:hover, .teleport-button:focus-visible {
+    border-color: rgba(185, 210, 158, .50); color: #f0f4ec;
+    background: rgba(62, 91, 61, .42); outline: none;
+  }
+  .teleport-button kbd {
+    display: grid; place-items: center; width: 20px; height: 20px;
+    box-sizing: border-box; border: 1px solid rgba(202, 221, 193, .30);
+    border-radius: 3px; color: #d8e4d1; background: rgba(185, 210, 158, .13);
+    font: 600 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .telemetry-footnote { margin-top: 8px; color: #71806c; font-size: 8px; letter-spacing: .08em; }
   #boot {
-    position: fixed; inset: 0; display: grid; place-items: center;
+    position: fixed; inset: 0; z-index: 20; display: grid; place-items: center;
     font: 300 13px/1.7 ui-sans-serif, system-ui, sans-serif;
     letter-spacing: .22em; text-transform: uppercase; color: #6d7a63;
     background: #05070a; pointer-events: none;
+  }
+  #boot[hidden] { display: none; }
+  .boot-panel { width: min(420px, calc(100vw - 48px)); text-align: center; }
+  .boot-title { color: #e8eee2; font: 300 38px/.95 Georgia, serif; letter-spacing: -.025em; text-transform: none; }
+  #boot-status { min-height: 22px; margin-top: 22px; color: #a2b596; font-size: 11px; }
+  .boot-track { height: 3px; margin-top: 12px; overflow: hidden; background: rgba(176, 199, 162, .18); }
+  #boot-fill { display: block; width: 0%; height: 100%; background: #b9d29e; transition: width .2s ease-out; }
+  #boot-percent { margin-top: 10px; color: #6d7a63; font-size: 11px; letter-spacing: .18em; }
+  #scenario-menu {
+    position: fixed; inset: 0; z-index: 10; display: flex; align-items: center;
+    justify-content: center; overflow: auto;
+    padding: 24px; box-sizing: border-box; color: #e9eee5;
+    background:
+      radial-gradient(circle at 50% 42%, rgba(91, 115, 76, .20), transparent 36%),
+      linear-gradient(145deg, #0b120e 0%, #111b15 52%, #080d0b 100%);
+    font: 400 16px/1.5 ui-sans-serif, system-ui, sans-serif;
+  }
+  #scenario-menu[hidden] { display: none; }
+  .scenario-panel { width: min(720px, 100%); text-align: center; }
+  .scenario-kicker {
+    margin: 0 0 14px; color: #a2b596; font-size: 11px; font-weight: 600;
+    letter-spacing: .28em; text-transform: uppercase;
+  }
+  .scenario-title {
+    margin: 0; color: #f3f5ee; font: 300 clamp(42px, 8vw, 76px)/.95 Georgia, serif;
+    letter-spacing: -.035em;
+  }
+  .scenario-copy { margin: 22px auto 32px; max-width: 430px; color: #b8c2b3; }
+  .scenario-options {
+    display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px;
+  }
+  .scenario-choice {
+    min-height: 132px; padding: 22px 18px; border: 1px solid rgba(202, 221, 193, .26);
+    border-radius: 3px; color: #eef3e9; background: rgba(13, 23, 17, .62);
+    cursor: pointer; text-align: left; transition: border-color .18s, background .18s,
+      transform .18s; font: inherit;
+  }
+  .scenario-choice:hover, .scenario-choice:focus-visible {
+    border-color: #b9d29e; background: rgba(62, 91, 61, .55); outline: none;
+    transform: translateY(-2px);
+  }
+  .scenario-choice strong { display: block; margin-bottom: 8px; font: 400 26px/1 Georgia, serif; }
+  .scenario-choice span { display: block; color: #aebbaa; font-size: 13px; }
+  @media (max-width: 520px) {
+    .scenario-options { grid-template-columns: 1fr; }
+    .scenario-choice { min-height: 0; }
+  }
+  @media (max-height: 600px) {
+    #scenario-menu { align-items: flex-start; }
+    .scenario-panel { margin: 24px 0; }
+  }
+  #pause-menu {
+    position: fixed; inset: 0; z-index: 30; display: grid; place-items: center;
+    overflow: auto; padding: 24px; box-sizing: border-box; color: #e9eee5;
+    background: rgba(4, 7, 5, .74); backdrop-filter: blur(7px);
+    font: 400 16px/1.5 ui-sans-serif, system-ui, sans-serif;
+  }
+  #pause-menu[hidden] { display: none; }
+  .pause-panel {
+    width: min(520px, 100%); padding: 36px; box-sizing: border-box;
+    border: 1px solid rgba(202, 221, 193, .24); border-radius: 4px;
+    background: rgba(12, 21, 15, .94); box-shadow: 0 24px 80px rgba(0, 0, 0, .38);
+    text-align: center;
+  }
+  .pause-kicker {
+    margin: 0 0 12px; color: #a2b596; font-size: 11px; font-weight: 600;
+    letter-spacing: .28em; text-transform: uppercase;
+  }
+  .pause-title {
+    margin: 0; color: #f3f5ee; font: 300 clamp(38px, 7vw, 58px)/.95 Georgia, serif;
+    letter-spacing: -.035em;
+  }
+  .pause-copy { margin: 18px auto 26px; max-width: 390px; color: #b8c2b3; }
+  .pause-actions { display: grid; gap: 10px; }
+  .pause-button {
+    min-height: 48px; padding: 12px 16px; border: 1px solid rgba(202, 221, 193, .26);
+    border-radius: 3px; color: #eef3e9; background: rgba(28, 48, 31, .72);
+    cursor: pointer; font: inherit; transition: border-color .18s, background .18s;
+  }
+  .pause-button:hover, .pause-button:focus-visible {
+    border-color: #b9d29e; background: rgba(62, 91, 61, .72); outline: none;
+  }
+  .pause-button.primary { color: #142016; background: #b9d29e; border-color: #b9d29e; }
+  .pause-button.primary:hover, .pause-button.primary:focus-visible { background: #d0e5ba; }
+  .pause-scenario-label {
+    margin: 12px 0 0; color: #8f9f89; font-size: 11px;
+    letter-spacing: .18em; text-transform: uppercase;
+  }
+  .pause-scenarios { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+  .pause-button.danger { margin-top: 8px; color: #d8b9aa; background: rgba(74, 35, 28, .36); }
+  .pause-button.danger:hover, .pause-button.danger:focus-visible {
+    border-color: #d8a998; background: rgba(96, 46, 36, .58);
+  }
+  @media (max-width: 520px) {
+    .pause-panel { padding: 28px 20px; }
   }
 </style>
 <script type="importmap">
@@ -28,7 +159,64 @@
 </head>
 <body>
 <canvas id="view"></canvas>
-<div id="boot">jungle trail</div>
+<aside id="telemetry" hidden aria-label="Performance and teleport controls">
+  <div class="telemetry-metrics">
+    <div class="telemetry-metric"><span>FPS</span><strong id="fps-value">—</strong></div>
+    <div class="telemetry-metric"><span>CPU</span><strong id="cpu-value">—</strong></div>
+    <div class="telemetry-metric"><span>GPU</span><strong id="gpu-value">—</strong></div>
+  </div>
+  <div class="telemetry-divider"></div>
+  <div class="teleport-heading"><span>Teleport</span><span>Press a key</span></div>
+  <div class="teleport-list">
+    <button class="teleport-button" type="button" data-teleport="1"><kbd>1</kbd><span>Trailhead</span></button>
+    <button class="teleport-button" type="button" data-teleport="2"><kbd>2</kbd><span>Mid trail</span></button>
+    <button class="teleport-button" type="button" data-teleport="3"><kbd>3</kbd><span>Ruins approach</span></button>
+    <button class="teleport-button" type="button" data-teleport="4"><kbd>4</kbd><span>Temple clearing</span></button>
+    <button class="teleport-button" type="button" data-teleport="5"><kbd>5</kbd><span>The falls</span></button>
+  </div>
+  <div class="telemetry-footnote">CPU/GPU = frame load</div>
+</aside>
+<div id="boot" hidden role="status" aria-live="polite" aria-busy="true">
+  <div class="boot-panel">
+    <div class="boot-title">Jungle Trail</div>
+    <div id="boot-status">Preparing your trail…</div>
+    <div class="boot-track" aria-hidden="true"><span id="boot-fill"></span></div>
+    <div id="boot-percent">0%</div>
+  </div>
+</div>
+<main id="scenario-menu" aria-labelledby="scenario-title">
+  <section class="scenario-panel">
+    <p class="scenario-kicker">Choose your trail</p>
+    <h1 class="scenario-title" id="scenario-title">Jungle Trail</h1>
+    <p class="scenario-copy">Select a world to explore. Each trail has its own atmosphere, vegetation and soundscape.</p>
+    <div class="scenario-options">
+      <button class="scenario-choice" type="button" data-scenario="jungle">
+        <strong>Jungle</strong>
+        <span>Humid green canopy, tropical undergrowth and the original trail.</span>
+      </button>
+      <button class="scenario-choice" type="button" data-scenario="forest">
+        <strong>Forest</strong>
+        <span>Autumn leaves, temperate ground and a cooler woodland atmosphere.</span>
+      </button>
+    </div>
+  </section>
+</main>
+<aside id="pause-menu" hidden role="dialog" aria-labelledby="pause-title" aria-modal="true">
+  <section class="pause-panel">
+    <p class="pause-kicker">Scenario paused</p>
+    <h2 class="pause-title" id="pause-title">Pause</h2>
+    <p class="pause-copy">The trail is paused. Resume your walk or choose another way to continue.</p>
+    <div class="pause-actions">
+      <button class="pause-button primary" id="pause-resume" type="button">Resume</button>
+      <p class="pause-scenario-label">Change scenario</p>
+      <div class="pause-scenarios">
+        <button class="pause-button" type="button" data-pause-scenario="jungle">Jungle</button>
+        <button class="pause-button" type="button" data-pause-scenario="forest">Forest</button>
+      </div>
+      <button class="pause-button danger" id="pause-exit" type="button">Exit to start menu</button>
+    </div>
+  </section>
+</aside>
 <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "First-person jungle trail. Procedural everything, zero external assets.",
   "scripts": {
     "serve": "node tools/serve.mjs",
-    "shoot": "node tools/shoot.mjs"
+    "shoot": "node tools/shoot.mjs",
+    "test": "node --test"
   },
   "devDependencies": {
     "playwright": "^1.62.0"

--- a/src/audio/engine.js
+++ b/src/audio/engine.js
@@ -119,7 +119,10 @@ export class Ambience {
       };
       d.addEventListener('pointerlockchange', tryUnlock);
       d.addEventListener('pointerdown', tryUnlock, { once: true });
-      this._detachDoc = () => d.removeEventListener('pointerlockchange', tryUnlock);
+      this._detachDoc = () => {
+        d.removeEventListener('pointerlockchange', tryUnlock);
+        d.removeEventListener('pointerdown', tryUnlock);
+      };
     }
 
     // Same convention as window.__game: the capture harness and anyone

--- a/src/audio/score.js
+++ b/src/audio/score.js
@@ -17,7 +17,7 @@ import { clamp, smoothstep, dbToGain } from './dsp.js';
  * loudest and constant, birds clearly above the bed but intermittent, wind
  * mostly subliminal, and the falls given enough headroom to genuinely
  * dominate the last fifty metres — the brief's one explicit crescendo. */
-export const LEVELS = {
+export const DEFAULT_LEVELS = Object.freeze({
   cicada: -25,
   crickets: -30,
   insectEvent: -30,
@@ -39,9 +39,31 @@ export const LEVELS = {
    * live at normal volume, with the compressor never touched except by a
    * close call landing on the crescendo. */
   master: 4,
-};
+});
+
+/* The live engine and the offline renderer share this mutable view so an
+ * explicitly selected scenario can affect both. Keeping an immutable baseline
+ * beside it makes switching back to jungle deterministic in the same module,
+ * which matters to capture tools and tests that construct more than one game. */
+export const LEVELS = { ...DEFAULT_LEVELS };
 
 export const levelGain = (name) => dbToGain(LEVELS[name]);
+
+/* Scenario overrides, applied by main.js at boot. Both renderers read LEVELS
+ * at call time rather than caching, so mutating the table here changes the
+ * live engine and the offline WAV tool without either one re-syncing. */
+export function setLevelOverrides(o = {}) {
+  if (!o || typeof o !== 'object') return LEVELS;
+  for (const k of Object.keys(o)) {
+    if (Object.hasOwn(DEFAULT_LEVELS, k) && Number.isFinite(o[k])) LEVELS[k] = o[k];
+  }
+  return LEVELS;
+}
+
+export function resetLevelOverrides() {
+  Object.assign(LEVELS, DEFAULT_LEVELS);
+  return LEVELS;
+}
 
 /* Trail geometry the audio needs, without importing path.js — path.js pulls
  * in three, which Node (and therefore the WAV tool) does not have. The

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@
  * load-bearing rather than debug convenience.
  */
 import * as THREE from 'three';
+import { SCENARIOS, explicitScenarioFor, scenarioFor } from './scenario.js';
+import { resetLevelOverrides, setLevelOverrides } from './audio/score.js';
 import { Trail } from './world/path.js';
 import { Terrain, makeTerrainMaterial } from './world/terrain.js';
 import { Sky } from './render/sky.js';
@@ -40,8 +42,10 @@ const TIERS = {
 const TIER_ORDER = ['low', 'medium', 'high', 'ultra'];
 
 class Game {
-  constructor(canvas) {
+  constructor(canvas, onProgress = null, onMetrics = null) {
     this.canvas = canvas;
+    this._onProgress = onProgress;
+    this._onMetrics = onMetrics;
     this.clock = new THREE.Clock();
     this.paused = false;
     this.running = false;
@@ -50,19 +54,51 @@ class Game {
     this._frames = 0;
     this._fpsT = 0;
     this._stableFor = 0;
+    /* Telemetry is intentionally split into what JavaScript can measure and
+     * what WebGL can measure. CPU is the time spent stepping and submitting a
+     * frame; GPU is an EXT_disjoint_timer_query measurement when the browser
+     * exposes one. Neither is pretending to be an operating-system process
+     * percentage. */
+    this._cpuMs = NaN;
+    this._gpuMs = NaN;
+    this._gpuTimer = null;
 
     const hash = new URLSearchParams(location.hash.slice(1));
-    this.pinnedTier = TIER_ORDER.includes(location.hash.slice(1)) ? location.hash.slice(1)
-                    : hash.get('tier');
+    const bareHash = location.hash.slice(1);
+    const bareFlag = bareHash.split('&', 1)[0];
+    const requestedTier = hash.get('tier');
+    this.pinnedTier = TIER_ORDER.includes(bareFlag) ? bareFlag
+                    : TIER_ORDER.includes(requestedTier) ? requestedTier : null;
     this.tier = this.pinnedTier || 'high';
     /* The user of this machine games on it. An uncapped loop on an RTX-class
      * card will happily render this at 300 fps and pull 150 W to do it, for a
      * scene that is a walking pace nature documentary. 60 is the target and
      * the cap. */
-    this.frameCap = Number(hash.get('fps')) || 60;
+    const requestedFps = Number(hash.get('fps'));
+    this.frameCap = Number.isFinite(requestedFps) && requestedFps > 0
+      ? Math.min(240, Math.max(1, requestedFps)) : 60;
 
+    /* The scenario is the biome: `#forest`, `#scenario=forest` or default
+     * jungle. It drives the atmosphere, the ground and leaf palettes, the
+     * vegetation weights and the audio score below. */
+    this.scenario = SCENARIOS[scenarioFor(location.hash)];
+  }
+
+  _progress(percent, status) { this._onProgress?.(percent, status); }
+
+  _yieldBoot() {
+    return new Promise((resolve) => {
+      if (typeof requestAnimationFrame === 'function') requestAnimationFrame(resolve);
+      else setTimeout(resolve, 0);
+    });
+  }
+
+  async init() {
+    this._progress(4, 'Preparing the renderer…');
     this._initRenderer();
-    this._initScene();
+    await this._yieldBoot();
+    await this._initScene();
+    this._progress(100, 'Ready');
   }
 
   _initRenderer() {
@@ -99,18 +135,92 @@ class Game {
     r.setPixelRatio(Math.min(devicePixelRatio, TIERS[this.tier].dpr));
     r.setSize(innerWidth, innerHeight, false);
     this.renderer = r;
+    this._initGpuTimer();
 
-    addEventListener('resize', () => this.resize());
+    this._onResize = () => this.resize();
+    addEventListener('resize', this._onResize);
   }
 
-  _initScene() {
+  _initGpuTimer() {
+    const gl = this.renderer?.getContext?.();
+    const ext = gl?.getExtension?.('EXT_disjoint_timer_query_webgl2');
+    if (!gl || !ext || typeof gl.createQuery !== 'function') return;
+    this._gpuTimer = { gl, ext, active: null, pending: null };
+  }
+
+  _pollGpuTimer() {
+    const timer = this._gpuTimer;
+    if (!timer?.pending) return;
+    const { gl, ext, pending } = timer;
+    try {
+      if (!gl.getQueryParameter(pending, gl.QUERY_RESULT_AVAILABLE)) return;
+      const disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+      if (!disjoint) {
+        const ns = Number(gl.getQueryParameter(pending, gl.QUERY_RESULT));
+        if (Number.isFinite(ns)) this._gpuMs = ns / 1e6;
+      }
+      gl.deleteQuery(pending);
+      timer.pending = null;
+    } catch (_) {
+      /* Context loss or an incomplete extension must not break the render loop. */
+      try { gl.deleteQuery(pending); } catch (_) { /* already gone */ }
+      timer.pending = null;
+    }
+  }
+
+  _beginGpuTimer() {
+    const timer = this._gpuTimer;
+    if (!timer || timer.active || timer.pending) return;
+    try {
+      const query = timer.gl.createQuery();
+      timer.gl.beginQuery(timer.ext.TIME_ELAPSED_EXT, query);
+      timer.active = query;
+    } catch (_) {
+      timer.active = null;
+    }
+  }
+
+  _endGpuTimer() {
+    const timer = this._gpuTimer;
+    if (!timer?.active) return;
+    try {
+      timer.gl.endQuery(timer.ext.TIME_ELAPSED_EXT);
+      timer.pending = timer.active;
+      timer.active = null;
+    } catch (_) {
+      try { timer.gl.deleteQuery(timer.active); } catch (_) { /* already gone */ }
+      timer.active = null;
+    }
+  }
+
+  _disposeGpuTimer() {
+    const timer = this._gpuTimer;
+    if (!timer) return;
+    try {
+      if (timer.active) timer.gl.endQuery(timer.ext.TIME_ELAPSED_EXT);
+    } catch (_) { /* context may already be lost */ }
+    for (const query of [timer.active, timer.pending]) {
+      if (query) {
+        try { timer.gl.deleteQuery(query); } catch (_) { /* already gone */ }
+      }
+    }
+    this._gpuTimer = null;
+  }
+
+  _recordCpu(ms) {
+    this._cpuMs = Number.isFinite(this._cpuMs) ? this._cpuMs * 0.82 + ms * 0.18 : ms;
+  }
+
+  async _initScene() {
+    this._progress(9, 'Setting the sky and sunlight…');
     const scene = new THREE.Scene();
     this.scene = scene;
 
     this.camera = new THREE.PerspectiveCamera(58, innerWidth / innerHeight, 0.08, 900);
 
     this.sky = new Sky(this.renderer);
-    this.sky.setSun(38, 152);
+    this.sky.setSun(this.scenario.atmosphere.sunEl, this.scenario.atmosphere.sunAz);
+    this.sky.setAtmosphere(this.scenario.atmosphere);
     scene.add(this.sky.mesh);
 
     /* Depth cue. Real jungle air is thick with water vapour and the visibility
@@ -136,7 +246,8 @@ class Game {
      * sage as they receded — the middle distance was not losing detail
      * gradually, it was being clamped flat. A darker, greyer haze lets the far
      * boles keep their silhouettes while still closing the corridor off. */
-    scene.fog = new THREE.FogExp2(0x323c2c, 0.038);
+    scene.fog = new THREE.FogExp2(this.scenario.atmosphere.fogColor,
+                                  this.scenario.atmosphere.fogDensity);
 
     const sl = this.sky.sunLight();
     this.sun = new THREE.DirectionalLight(sl.color, sl.intensity);
@@ -217,8 +328,13 @@ class Game {
      * puts a well of light under itself and a thick one does not. This is what
      * is left: the isotropic floor under everything, which still has to exist,
      * because there is no black in a jungle shadow. */
-    this.hemi = new THREE.HemisphereLight(0x82a081, 0x63513a, 0.55);
+    this.hemi = new THREE.HemisphereLight(this.scenario.atmosphere.hemiSky,
+                                          this.scenario.atmosphere.hemiGround,
+                                          this.scenario.atmosphere.hemiIntensity);
     scene.add(this.hemi);
+
+    this._progress(17, 'Sculpting the trail…');
+    await this._yieldBoot();
 
     /* The scene used to carry a second, weak, unshadowed DirectionalLight here
      * standing in for skylight that had been through the canopy. It has been
@@ -241,8 +357,11 @@ class Game {
      * the stone and refuse to grow through it. */
     this.ruinPlan = new RuinPlan(this.trail);
     this.terrain = new Terrain(this.trail, undefined, this.ruinPlan);
-    this.terrainMat = makeTerrainMaterial(this.renderer);
+    this.terrainMat = makeTerrainMaterial(this.renderer, this.scenario.groundSet);
     scene.add(this.terrain.build(this.terrainMat));
+
+    this._progress(34, 'Building the ancient ruins…');
+    await this._yieldBoot();
 
     /* Solids are registered while their procedural generators still know
      * what each merged or instanced piece represents. Keeping this registry
@@ -255,8 +374,13 @@ class Game {
     scene.add(this.ruins.root);
 
     this.veg = new Vegetation(this.renderer, this.terrain, this.trail, undefined,
-                              this.ruins, this.collision);
+                              this.ruins, this.collision,
+                              { palette: this.scenario.leafPalette,
+                                tuning: this.scenario.vegetation });
     scene.add(this.veg.root);
+
+    this._progress(64, 'Growing the surrounding vegetation…');
+    await this._yieldBoot();
 
     /* Built after the vegetation, and the order matters even though water
      * grows nothing. Every surface in it is clipped per fragment against the
@@ -269,6 +393,9 @@ class Game {
                            { tier: this.tier });
     scene.add(this.water.root);
 
+    this._progress(75, 'Adding water and surface details…');
+    await this._yieldBoot();
+
     this.sky.bake(scene);
     /* The environment map is the open sky, and under a roof of leaves only a
      * fraction of it is visible from any surface. Handing surfaces the full
@@ -277,7 +404,7 @@ class Game {
      * was coming from: those blades are near-horizontal and face straight up
      * into it. The hemisphere light above carries the fill instead, because
      * its upper colour is the underside of the canopy rather than the sky. */
-    scene.environmentIntensity = 0.34;
+    scene.environmentIntensity = this.scenario.atmosphere.envIntensity;
 
     this.walker = new Walker(this.camera, this.terrain, this.trail,
                              this.collision).attach(this.canvas);
@@ -290,6 +417,9 @@ class Game {
      * without rebuilding the character or accepting doubled limbs. */
     this.camera.layers.enable(BODY_FIRST_PERSON_LAYER);
 
+    this._progress(86, 'Finishing the atmosphere and lighting…');
+    await this._yieldBoot();
+
     /* Everything above builds surfaces; everything below decides how they are
      * lit. The order is forced — the field has to be sampled from a terrain
      * that has finished building, and the materials have to exist before they
@@ -299,6 +429,7 @@ class Game {
     this.canopy = new Canopy(this.renderer, this.field);
     this.canopy.setSun(this.sky.sunDir);
     this.atmos = new Atmosphere(this.renderer, this.canopy);
+    this.atmos.setMistAmbient(this.scenario.atmosphere.mistAmbient);
     this.atmos.setTier(this.tier);
     this._syncAtmosphereSize();
 
@@ -311,6 +442,9 @@ class Game {
                      ...this.body.materials]) {
       patchCanopyLight(m, this.canopy);
     }
+
+    this._progress(94, 'Preparing the soundscape…');
+    await this._yieldBoot();
 
     /* Nothing is allocated on the audio device here and no buffer is
      * synthesized: constructing Ambience only chains the walker's footfall
@@ -336,6 +470,11 @@ class Game {
      * in front of you is. */
     this.ambience.setWaterfallPosition(IMPACT, LIP);
     this.atmos.setFallsPlume(IMPACT);
+    /* The scenario's score overrides (a temperate wood is birds and wind,
+     * not cicadas) land here, after the engine exists but before any gain is
+     * ever evaluated — the unlock happens on the first pointer lock. */
+    resetLevelOverrides();
+    if (this.scenario.audio) setLevelOverrides(this.scenario.audio);
   }
 
   _configureShadow() {
@@ -440,6 +579,8 @@ class Game {
 
   render() {
     const r = this.renderer;
+    this._pollGpuTimer();
+    this._beginGpuTimer();
     /* The materials reconstruct world position from vViewPosition, so they
      * need the camera's world matrix as a uniform. Set once per frame here
      * rather than per material, because they all share the same uniform
@@ -459,6 +600,7 @@ class Game {
     this._sceneCalls = r.info.render.calls;
     this._sceneTris = r.info.render.triangles;
     this.atmos.finish(this.camera, this.sun.color, this.sun.intensity);
+    this._endGpuTimer();
   }
 
   renderOnce() { this.render(); }
@@ -483,8 +625,11 @@ class Game {
       const step = this._acc;
       this._acc = 0;
 
+      const cpuStart = performance.now();
       this.step(step);
       this.render();
+      this._recordCpu(performance.now() - cpuStart);
+      this._onMetrics?.(this.metrics());
 
       this._frames++;
       this._fpsT += step;
@@ -500,6 +645,17 @@ class Game {
   setPaused(p) {
     this.paused = !!p;
     this.ambience?.setPaused(this.paused);
+  }
+
+  metrics() {
+    const budget = 1000 / this.frameCap;
+    const percent = (ms) => Number.isFinite(ms) ? (100 * ms / budget) : null;
+    return {
+      fps: this.fps,
+      cpu: percent(this._cpuMs),
+      gpu: percent(this._gpuMs),
+      gpuTimed: !!this._gpuTimer,
+    };
   }
 
   /** Advance the simulation without waiting for wall-clock time. */
@@ -580,48 +736,237 @@ class Game {
   }
 
   dispose() {
+    if (this._disposed) return;
+    this._disposed = true;
+    this.running = false;
     cancelAnimationFrame(this._raf);
+    this._raf = 0;
+    this._disposeGpuTimer();
+    if (this._onResize) {
+      removeEventListener('resize', this._onResize);
+      this._onResize = null;
+    }
     this.ambience?.dispose();
-    this.walker.dispose();
-    this.body.dispose();
+    this.walker?.dispose();
+    this.body?.dispose();
+    this.water?.dispose();
+    this.veg?.dispose();
+    this.ruins?.dispose();
+    this.terrain?.dispose();
+    for (const map of Object.values(this.terrainMat?.userData?.maps || {})) map.dispose?.();
+    this.terrainMat?.dispose();
+    if (this.scene) this.scene.environment = null;
+    this.sky?.dispose();
     this.atmos?.dispose();
     this.canopy?.dispose();
-    this.renderer.dispose();
+    this.renderer?.dispose();
   }
 }
 
 const _size = new THREE.Vector2();
 
-const game = new Game(document.getElementById('view'));
-window.__game = game;
-window.THREE = THREE;
-
-/* Recording convenience: number keys jump to the authored viewpoints.
- *
- * The falls are eight minutes of walking from the trailhead, which is the
- * right length for the level and the wrong length for the twentieth take of a
- * capture. These reuse goTo() rather than moving the camera themselves, so a
- * warp lands in exactly the state the harness's stops land in — snapped to the
- * heightfield, facing along the trail, velocity zeroed, gait clock reset.
- *
- * Nothing is drawn and nothing is logged. The frame has no UI in it at all,
- * and a debug aid is the last thing that should be the exception. Delete this
- * block for a public build; the feature is nowhere else.
- */
+const canvas = document.getElementById('view');
+const menu = document.getElementById('scenario-menu');
+const telemetry = document.getElementById('telemetry');
+const fpsValue = document.getElementById('fps-value');
+const cpuValue = document.getElementById('cpu-value');
+const gpuValue = document.getElementById('gpu-value');
+const pauseMenu = document.getElementById('pause-menu');
+const pauseResume = document.getElementById('pause-resume');
+const pauseExit = document.getElementById('pause-exit');
+const bootLabel = document.getElementById('boot');
+const bootStatus = document.getElementById('boot-status');
+const bootFill = document.getElementById('boot-fill');
+const bootPercent = document.getElementById('boot-percent');
+const isManual = /(^|[#&])manual(&|$)/.test(location.hash);
+let game = null;
+let bootPromise = null;
+let removeDebugControls = null;
 const WARP_STOPS = [0.04, 0.34, 0.81, 0.88, 0.96];
-addEventListener('keydown', (e) => {
-  /* Only while the pointer is locked. A digit typed at a page that merely has
-   * focus is not a request to move the player, and gating on the same flag the
-   * walker uses means the capture harness — which drives goTo() directly and
-   * never sends key events — cannot be perturbed by this at all. */
-  if (!game.walker.enabled) return;
-  const key = /^Digit([1-9])$/.exec(e.code);
-  const t = key && WARP_STOPS[+key[1] - 1];
-  if (t === undefined || t === null) return;
-  game.goTo(t);
+
+function showBootProgress(percent, status) {
+  const value = Math.max(0, Math.min(100, Math.round(percent)));
+  if (bootLabel) bootLabel.hidden = false;
+  if (bootStatus) bootStatus.textContent = status;
+  if (bootFill) bootFill.style.width = `${value}%`;
+  if (bootPercent) bootPercent.textContent = `${value}%`;
+}
+
+function showTelemetry() {
+  if (!isManual) {
+    telemetry?.removeAttribute('hidden');
+    updateTelemetry();
+  }
+}
+
+function hideTelemetry() {
+  telemetry?.setAttribute('hidden', '');
+}
+
+function metricText(value, suffix = '') {
+  return Number.isFinite(value) ? `${Math.round(value)}${suffix}` : 'n/d';
+}
+
+function updateTelemetry(metrics = game?.metrics()) {
+  if (!metrics || telemetry?.hidden) return;
+  fpsValue.textContent = metricText(metrics.fps);
+  cpuValue.textContent = metricText(metrics.cpu, '%');
+  gpuValue.textContent = metricText(metrics.gpu, '%');
+  gpuValue.title = metrics.gpuTimed
+    ? 'GPU: WebGL timer query, rapportato al budget del frame'
+    : 'GPU: misura non disponibile in questo browser';
+}
+
+function refreshTelemetry() {
+  if (!telemetry) return;
+  updateTelemetry();
+  window.setTimeout(refreshTelemetry, 250);
+}
+
+function writeScenarioHash(id) {
+  const keep = location.hash.slice(1).split('&').filter(Boolean).filter((part) =>
+    part === 'manual' || /^(?:tier|fps)=/.test(part));
+  const next = [`scenario=${encodeURIComponent(id)}`, ...keep].join('&');
+  history.replaceState(null, '', `#${next}`);
+}
+
+function hidePauseMenu() {
+  pauseMenu?.setAttribute('hidden', '');
+}
+
+function showPauseMenu() {
+  if (!game || !game.running || !bootLabel?.hidden) return;
+  game.setPaused(true);
+  document.exitPointerLock?.();
+  hideTelemetry();
+  pauseMenu?.removeAttribute('hidden');
+  pauseResume?.focus({ preventScroll: true });
+}
+
+function resumeGame() {
+  if (!game || !game.running) return;
+  hidePauseMenu();
+  game.setPaused(false);
+  showTelemetry();
+  /* Re-locking from a button click is allowed as a user gesture. If the
+   * browser declines it, the canvas click handler remains the fallback. */
+  const request = canvas?.requestPointerLock?.();
+  request?.catch?.(() => {});
+}
+
+function destroyGame() {
+  document.exitPointerLock?.();
+  removeDebugControls?.();
+  removeDebugControls = null;
+  game?.dispose();
+  game = null;
+  window.__game = null;
+  hideTelemetry();
+}
+
+function showScenarioMenu() {
+  hidePauseMenu();
+  if (bootLabel) bootLabel.hidden = true;
+  menu?.removeAttribute('hidden');
+  menu?.querySelector('[data-scenario]')?.focus({ preventScroll: true });
+}
+
+function exitToScenarioMenu() {
+  destroyGame();
+  history.replaceState(null, '', `${location.pathname}${location.search}`);
+  showScenarioMenu();
+}
+
+function teleportTo(activeGame, index, fromKeyboard = false) {
+  if (!activeGame || !activeGame.running || activeGame.paused) return false;
+  if (fromKeyboard && !activeGame.walker?.enabled) return false;
+  const t = WARP_STOPS[index];
+  if (t === undefined) return false;
+  activeGame.goTo(t);
+  return true;
+}
+
+function wireDebugControls(activeGame) {
+  /* The same authored viewpoints are exposed as keyboard shortcuts and as
+   * buttons, so the player never has to guess an undocumented debug command. */
+  const onKeydown = (e) => {
+    const key = /^(?:Digit|Numpad)([1-5])$/.exec(e.code);
+    if (!key) return;
+    if (teleportTo(activeGame, +key[1] - 1, true)) e.preventDefault();
+  };
+  addEventListener('keydown', onKeydown);
+  const buttons = [...(telemetry?.querySelectorAll('[data-teleport]') || [])];
+  const buttonHandlers = buttons.map((button) => {
+    const onClick = () => teleportTo(activeGame, Number(button.dataset.teleport) - 1);
+    button.addEventListener('click', onClick);
+    return [button, onClick];
+  });
+  return () => {
+    removeEventListener('keydown', onKeydown);
+    for (const [button, onClick] of buttonHandlers) button.removeEventListener('click', onClick);
+  };
+}
+
+async function bootGame() {
+  if (game) return game;
+  if (bootPromise) return bootPromise;
+
+  menu?.setAttribute('hidden', '');
+  showBootProgress(0, 'Starting your trail…');
+  const activeGame = new Game(canvas, showBootProgress, updateTelemetry);
+  bootPromise = (async () => {
+    try {
+      await activeGame.init();
+      game = activeGame;
+      window.__game = game;
+      window.THREE = THREE;
+      removeDebugControls = wireDebugControls(game);
+      if (!isManual) game.begin();
+      if (bootLabel) bootLabel.hidden = true;
+      showTelemetry();
+      return game;
+    } catch (error) {
+      console.error('[boot] failed:', error);
+      activeGame.dispose();
+      hideTelemetry();
+      menu?.removeAttribute('hidden');
+      showBootProgress(0, 'Unable to load the trail. Choose a scenario to retry.');
+      return null;
+    } finally {
+      bootPromise = null;
+    }
+  })();
+  return bootPromise;
+}
+
+function chooseScenario(id) {
+  if (!Object.hasOwn(SCENARIOS, id)) return;
+  if (game) destroyGame();
+  hidePauseMenu();
+  writeScenarioHash(id);
+  void bootGame();
+}
+
+menu?.querySelectorAll('[data-scenario]').forEach((button) => {
+  button.addEventListener('click', () => chooseScenario(button.dataset.scenario));
 });
 
-// The harness calls begin() itself so it can set state before the first frame.
-if (!/(^|[#&])manual(&|$)/.test(location.hash)) game.begin();
+pauseResume?.addEventListener('click', resumeGame);
+pauseExit?.addEventListener('click', exitToScenarioMenu);
+pauseMenu?.querySelectorAll('[data-pause-scenario]').forEach((button) => {
+  button.addEventListener('click', () => chooseScenario(button.dataset.pauseScenario));
+});
 
-document.getElementById('boot')?.remove();
+refreshTelemetry();
+
+addEventListener('keydown', (e) => {
+  if (e.code !== 'Escape' || !game || !game.running || !bootLabel?.hidden) return;
+  e.preventDefault();
+  if (pauseMenu?.hidden) showPauseMenu();
+  else resumeGame();
+});
+
+/* Explicit URLs remain deep-linkable, and the manual flag is reserved for the
+ * capture harness. A clean browser launch gets the picker before any WebGL
+ * allocation begins. */
+if (explicitScenarioFor(location.hash) || isManual) void bootGame();

--- a/src/render/atmosphere.js
+++ b/src/render/atmosphere.js
@@ -835,6 +835,11 @@ export class Atmosphere {
    * canopy the atmosphere owns — and inverting that would mean the water
    * could not be lit like everything else.
    */
+  setMistAmbient(color = 0x11170f) {
+    this.volumeMat.uniforms.uMistAmbient.value.set(color);
+    return this;
+  }
+
   setFallsPlume(impact, radius = 12.0) {
     this.volumeMat.uniforms.uPlume.value.set(impact.x, impact.y, impact.z, radius);
   }

--- a/src/render/sky.js
+++ b/src/render/sky.js
@@ -204,6 +204,17 @@ export class Sky {
   get sunDir() { return this.uniforms.uSunDir.value; }
 
   /**
+   * Tune the low dome colours with the scene fog. Keeping these as scenario
+   * inputs prevents a biome from changing its distance fog while retaining a
+   * green horizon baked into the sky and environment map.
+   */
+  setAtmosphere({ skyGround = 0x4d5a41, skyHaze = 0x475538 } = {}) {
+    this.uniforms.uGroundColor.value.set(skyGround);
+    this.uniforms.uHazeColor.value.set(skyHaze);
+    return this;
+  }
+
+  /**
    * Set the sun by elevation/azimuth in degrees.
    * Elevation around 32-42 is the useful window: high enough that shafts reach
    * the floor through the canopy, low enough that they are still shafts.

--- a/src/scenario.js
+++ b/src/scenario.js
@@ -1,0 +1,108 @@
+/* Scenario registry.
+ *
+ * The same world-builder spine — trail, heightfield, vegetation, atmosphere —
+ * serves different biomes by swapping a few authored layers: which ground
+ * surfaces bake, which leaf palette the atlas uses, how the species weights
+ * lean, and how the atmosphere is tuned. `jungle` reproduces the original
+ * values exactly; `forest` is a temperate deciduous autumn variant.
+ *
+ * Selecting: use the opening picker, or append `#forest` (or
+ * `#scenario=forest`) to the URL. The capture harness and the browser read the
+ * same hash, so `#scenario=forest&manual` is the deterministic way to drive
+ * the tools against the forest.
+ *
+ * The vegetation block is the one partial knob in this version: palmScale and
+ * broadleafScale scale the placement accept probabilities for those species,
+ * and the tint/senescence values nudge the per-instance colour variation.
+ * A conifer species (evergreen) is the planned extension; the flag exists so
+ * the contract does not have to change when it lands.
+ */
+
+export const SCENARIOS = {
+  jungle: {
+    id: 'jungle',
+    title: 'Jungle Trail',
+    /* The original tuning, kept verbatim so the default frame is unchanged. */
+    atmosphere: {
+      sunEl: 38, sunAz: 152,
+      fogColor: 0x323c2c, fogDensity: 0.038,
+      hemiSky: 0x82a081, hemiGround: 0x63513a, hemiIntensity: 0.55,
+      envIntensity: 0.34,
+      skyGround: 0x4d5a41, skyHaze: 0x475538,
+      mistAmbient: 0x11170f,
+    },
+    groundSet: 'jungle',
+    leafPalette: 'jungle',
+    vegetation: {
+      palmScale: 1, broadleafScale: 1, conifer: false,
+      tint: { rMul: 0.90, rSway: 0.16, bMul: 0.84, bSway: 0.20 },
+      senescent: { yellow: 0.93, olive: 0.84 },
+      woodTint: 0xffffff,
+    },
+    audio: null,   // no overrides — the rainforest score as tuned
+  },
+
+  forest: {
+    id: 'forest',
+    title: 'Temperate Forest — Autumn',
+    atmosphere: {
+      /* A lower, later-in-the-day autumn sun, greyer haze, and a warm soil
+       * bounce replacing the green litter bounce. The hemi steps back a
+       * little: the deciduous roof is thinner than three storeys of canopy,
+       * so more of the frame is carried by the sun and the environment. */
+      sunEl: 30, sunAz: 150,
+      fogColor: 0x46463a, fogDensity: 0.030,
+      hemiSky: 0x9c9c88, hemiGround: 0x5a4530, hemiIntensity: 0.50,
+      envIntensity: 0.38,
+      skyGround: 0x5a5a4e, skyHaze: 0x4b4b40,
+      mistAmbient: 0x171813,
+    },
+    groundSet: 'forest',
+    leafPalette: 'autumn',
+    vegetation: {
+      /* Palms are the single loudest tropical tell; at 0.05 they are gone.
+       * Broadleaf understory carries the deciduous look, so it is pushed up.
+       * Tints lean warm and slightly more plants read as senescing, which is
+       * what an autumn floor is actually doing. Wood gets a browner coat:
+       * the tropical bark is pale and smooth on purpose, and temperate bark
+       * reads wrong at that value. */
+      palmScale: 0.05, broadleafScale: 1.35, conifer: false,
+      tint: { rMul: 0.98, rSway: 0.10, bMul: 0.66, bSway: 0.14 },
+      senescent: { yellow: 0.85, olive: 0.76 },
+      woodTint: 0x8f8066,
+    },
+    audio: {
+      /* A temperate wood is birds and wind; the tropical beds step back.
+       * Falls and brook stay — a forest with a waterfall is the point. */
+      cicada: -33, crickets: -35,
+      birds: -16, rustle: -19, wash: -31,
+    },
+  },
+};
+
+/**
+ * Return the explicitly requested scenario, or null when the hash does not
+ * select one. Keeping this distinct from scenarioFor lets the app show its
+ * picker on a clean launch while retaining jungle as the runtime fallback.
+ *
+ * @param {string} hash  location.hash, with or without the leading '#'
+ * @returns {string|null}
+ */
+export function explicitScenarioFor(hash = '') {
+  const raw = String(hash).replace(/^#/, '');
+  const params = new URLSearchParams(raw);
+  const bare = raw.split('&', 1)[0];
+  const requested = params.get('scenario') || bare;
+  return requested && Object.hasOwn(SCENARIOS, requested) ? requested : null;
+}
+
+/**
+ * @param {string} hash  location.hash, with or without the leading '#'
+ * @returns {string} scenario id, always one of SCENARIOS
+ */
+export function scenarioFor(hash = '') {
+  /* A bare scenario may be followed by the same flags used by the harness,
+   * e.g. `#forest&tier=low`. Never use `in` here: location.hash is public
+   * input and inherited Object.prototype names are not scenarios. */
+  return explicitScenarioFor(hash) || 'jungle';
+}

--- a/src/world/groundTex.js
+++ b/src/world/groundTex.js
@@ -279,6 +279,164 @@ void surf(vec2 uv, out vec3 albedo, out float height, out float rough, out float
 }
 `;
 
+
+/* ── Temperate trail loam (forest set) ──────────────────────────────────────
+ * The same worn-dirt job as DIRT, but the soil is a brown loam with a cool
+ * cast rather than a red tropical clay: fewer stones, more roots, and autumn
+ * leaf fragments trodden into the surface. Same tiling contract as the rest
+ * of the file: p = uv * 8 and every noise period equals the scale on p.
+ */
+export const FLOAM = HELP + /* glsl */ `
+void surf(vec2 uv, out vec3 albedo, out float height, out float rough, out float ao){
+  vec2 p = uv * 8.0;
+
+  float mass   = unit(pfbm(p * 0.5, 4.0,  3));
+  float loam   = unit(pfbm(p,       8.0,  5));
+  float coarse = unit(pfbm(p * 4.0, 32.0, 4));
+
+  float root = sstep(0.86, 0.96, unit(pfbm(p * 1.2, 9.6, 3)));
+  float stone = sstep(0.62, 0.86, mass);
+  vec2 w1 = pworley(p * 6.0, 48.0);
+  float pebble = sstep(0.12 + 0.20 * coarse, 0.03, w1.x) * stone;
+
+  vec3 deep   = vec3(0.030, 0.024, 0.018);
+  vec3 mid    = vec3(0.070, 0.054, 0.034);
+  vec3 pale   = vec3(0.115, 0.090, 0.058);
+  vec3 stn    = vec3(0.240, 0.214, 0.170);
+  vec3 rootC  = vec3(0.120, 0.082, 0.050);
+
+  vec3 alb = mix(deep, mid, mass);
+  alb = mix(alb, pale, sstep(0.60, 0.95, loam) * 0.55);
+  alb = mix(alb, stn, pebble * 0.55);
+  alb = mix(alb, rootC, root * 0.85);
+
+  // Autumn litter trodden into the tread, in the same palette as FALLEN.
+  float bits = sstep(0.70, 0.90, unit(pfbm(p * 8.0, 64.0, 3)));
+  alb = mix(alb, vec3(0.240, 0.140, 0.060), bits * 0.30);
+
+  float wet = sstep(0.60, 0.90, unit(pfbm(p * 2.0, 16.0, 3)));
+  alb = mix(alb, vec3(0.016, 0.014, 0.011), wet * 0.55);
+
+  float burnish = sstep(0.62, 0.88, unit(pfbm(p * 1.5, 12.0, 3))) * (1.0 - wet);
+  height = 0.5 + (loam - 0.5) * 0.5 + pebble * 0.22 + root * 0.18;
+  height = mix(height, mix(height, 0.44, 0.7), burnish);
+
+  rough = mix(0.95, 0.16, wet);
+  rough = mix(rough, 0.70, burnish * 0.8);
+  rough = mix(rough, 0.64, pebble * 0.45);
+  rough = mix(rough, 0.50, root * 0.7);
+
+  albedo = alb;
+  ao = 1.0 - wet * 0.28 - (1.0 - height) * 0.35;
+}
+`;
+
+/* ── Autumn broadleaf litter (forest set) ───────────────────────────────────
+ * The same five-layer construction as LITTER, but the blades are bigger and
+ * broader — deciduous trees shed whole leaves, not shreds — and the palette
+ * is copper and rust instead of tan and olive.
+ */
+export const FALLEN = HELP + /* glsl */ `
+void surf(vec2 uv, out vec3 albedo, out float height, out float rough, out float ao){
+  vec2 p = uv * 8.0;
+
+  vec4 l0 = leafField(p * 0.45, vec2(3.6),  41.0, 0.60, 0.52);   // rare big blade
+  vec4 l1 = leafField(p,        vec2(8.0),  0.0,  0.55, 0.48);
+  vec4 l2 = leafField(p * 1.6,  vec2(12.8), 7.3,  0.50, 0.42);
+  vec4 l3 = leafField(p * 2.6,  vec2(20.8), 3.1,  0.60, 0.34);   // fragments
+  vec4 tw = leafField(p * 1.6,  vec2(12.8), 23.9, 0.95, 0.045);  // stalks
+
+  float soil = unit(pfbm(p * 2.0, 16.0, 5));
+  float rot  = unit(pfbm(p * 4.0, 32.0, 4));
+
+  vec3 humus = mix(vec3(0.050, 0.038, 0.028), vec3(0.110, 0.082, 0.050), soil);
+
+  // Charcoal where it has been down all winter, copper where it is fresh,
+  // and a thin olive line for the leaf that is only just turning.
+  vec3 black = vec3(0.070, 0.052, 0.036);
+  vec3 deep  = vec3(0.170, 0.096, 0.052);
+  vec3 mid   = vec3(0.300, 0.150, 0.066);
+  vec3 fresh = vec3(0.470, 0.210, 0.070);
+  vec3 olive = vec3(0.220, 0.170, 0.070);
+
+  vec3 col = humus;
+  height = soil * 0.18;
+
+  col = mix(col, mix(black, deep, l3.z * rot), l3.x);
+  height = mix(height, 0.26 + l3.y * 0.08,     l3.x);
+
+  col = mix(col, mix(deep, mid, l2.z),         l2.x);
+  height = mix(height, 0.42 + l2.y * 0.10,     l2.x);
+
+  col = mix(col, mix(mix(black, mid, rot), fresh, l1.z), l1.x);
+  height = mix(height, 0.58 + l1.y * 0.12,     l1.x);
+
+  col = mix(col, mix(olive, fresh, l0.z),      l0.x);
+  height = mix(height, 0.74 + l0.y * 0.14,     l0.x);
+
+  col = mix(col, vec3(0.120, 0.078, 0.048),    tw.x);
+  height = mix(height, 0.88,                   tw.x);
+
+  float rim = max(max(l1.x - l1.w, l2.x - l2.w), l0.x - l0.w);
+  float edge = sstep(0.35, 0.85, rim) * sstep(1.0, 0.55, rim);
+  height += edge * 0.20;
+
+  float ribs = max(max(l0.w, l1.w), max(l2.w, l3.w));
+  col = mix(col, col * 1.5 + 0.015, ribs * 0.55);
+  height += ribs * 0.05;
+
+  albedo = col;
+  float blade = max(max(l0.x, l1.x), l2.x);
+  rough = mix(0.95, 0.62, blade * 0.85 * (1.0 - rot * 0.5));
+  ao = 1.0 - (1.0 - height) * 0.78;
+}
+`;
+
+/* ── Cool wet rock (forest set) ─────────────────────────────────────────────
+ * The same bedding/grain/block construction as ROCK, but cooler and greyer
+ * and carrying heavier, greener lichen — the temperate look against the
+ * tropical tan crust.
+ */
+export const COOLROCK = HELP + /* glsl */ `
+void surf(vec2 uv, out vec3 albedo, out float height, out float rough, out float ao){
+  vec2 p = uv * 8.0;
+
+  float warp = pfbm(p, 8.0, 4) * 1.6;
+  float strata = pfbm(vec2(p.x * 0.5, p.y * 3.0 + warp), vec2(4.0, 24.0), 4);
+  float bed = abs(strata);
+
+  vec2 agg = pworley(p * 8.0, 64.0);
+  float grain = sstep(0.30, 0.0, agg.y - agg.x);
+
+  vec2 blk = pworley(p * 2.0, 16.0);
+  float blocks = sstep(0.26, 0.03, blk.y - blk.x);
+
+  float chip = unit(pfbm(p * 12.0, 96.0, 3));
+
+  height = 0.5 + strata * 0.26 - blocks * 0.40 - grain * 0.08 + chip * 0.08;
+
+  vec3 pale = vec3(0.360, 0.360, 0.340);
+  vec3 dark = vec3(0.120, 0.118, 0.116);
+  vec3 warm = vec3(0.240, 0.208, 0.160);
+
+  albedo = mix(dark, pale, contrast(bed, 1.5));
+  albedo = mix(albedo, warm, chip * 0.30);
+  albedo *= 1.0 - blocks * 0.42;
+
+  float drip = unit(pfbm(vec2(p.x * 2.0, p.y * 0.5), vec2(16.0, 4.0), 4));
+  float seep = sstep(0.35, 0.85, blocks * 0.6 + drip * 0.7);
+  albedo *= 1.0 - seep * 0.38;
+
+  // Cooler, greener lichen than the tropical mineral crust.
+  float lichen = sstep(0.58, 0.82, unit(pfbm(p * 3.0, 24.0, 4))) * (1.0 - blocks);
+  albedo = mix(albedo, vec3(0.380, 0.430, 0.330), lichen * 0.50);
+
+  rough = mix(0.88, 0.26, seep);
+  rough = mix(rough, 0.95, lichen * 0.6);
+  ao = 1.0 - blocks * 0.55 - grain * 0.15;
+}
+`;
+
 /* Macro variation.
  * Tiling is not defeated by better tiles. However good a 1024 map is, the eye
  * finds the repeat within a couple of periods because the *average* colour of

--- a/src/world/plantTex.js
+++ b/src/world/plantTex.js
@@ -139,12 +139,53 @@ export function leafSpan(cell, vary, t) {
   return Math.min(1, w / 1.08);
 }
 
-/* uChannel: 0 albedo+alpha, 1 normal, 2 rough/translucency/alpha. */
-export const LEAF_FRAG = /* glsl */ `
+/* uChannel: 0 albedo+alpha, 1 normal, 2 rough/translucency/alpha.
+ *
+ * The palette block is injected per scenario: the whole atlas structure —
+ * shapes, damage, veins, cuticle — is shared, and only the paint changes.
+ * `jungle` is exactly the original values; `autumn` is the temperate
+ * deciduous set. Keeping them as GLSL consts in the prelude means the leaf
+ * geometry (leafSpan, plants.js) does not need a twin: the shape was never
+ * palette-dependent.
+ */
+export const LEAF_PALETTES = {
+  jungle: /* glsl */ `
+const vec3 LEAF_DEEP  = vec3(0.034, 0.077, 0.042);
+const vec3 LEAF_MID   = vec3(0.070, 0.137, 0.072);
+const vec3 LEAF_LITE  = vec3(0.126, 0.188, 0.104);
+const vec3 LEAF_VEIN  = vec3(0.155, 0.184, 0.082);
+const vec3 LEAF_RIB   = vec3(0.186, 0.206, 0.102);
+const vec3 LEAF_EDGE  = vec3(0.058, 0.094, 0.046);
+const vec3 LEAF_PALE  = vec3(0.158, 0.182, 0.096);
+const vec3 LEAF_CHLO  = vec3(0.228, 0.208, 0.100);
+const vec3 LEAF_NECR  = vec3(0.130, 0.084, 0.044);
+const vec3 LEAF_EPI   = vec3(0.124, 0.142, 0.108);
+const vec3 LEAF_EPIS  = vec3(0.086, 0.100, 0.062);
+const vec3 LEAF_FLUSH = vec3(0.174, 0.164, 0.100);
+`,
+  autumn: /* glsl */ `
+const vec3 LEAF_DEEP  = vec3(0.160, 0.045, 0.020);
+const vec3 LEAF_MID   = vec3(0.240, 0.100, 0.035);
+const vec3 LEAF_LITE  = vec3(0.330, 0.160, 0.055);
+const vec3 LEAF_VEIN  = vec3(0.300, 0.130, 0.045);
+const vec3 LEAF_RIB   = vec3(0.340, 0.160, 0.060);
+const vec3 LEAF_EDGE  = vec3(0.180, 0.070, 0.030);
+const vec3 LEAF_PALE  = vec3(0.300, 0.150, 0.060);
+const vec3 LEAF_CHLO  = vec3(0.420, 0.300, 0.090);
+const vec3 LEAF_NECR  = vec3(0.200, 0.100, 0.045);
+const vec3 LEAF_EPI   = vec3(0.240, 0.150, 0.080);
+const vec3 LEAF_EPIS  = vec3(0.200, 0.120, 0.060);
+const vec3 LEAF_FLUSH = vec3(0.360, 0.240, 0.110);
+`,
+};
+
+function leafFragSource(PALETTE_GLSL) {
+  return /* glsl */ `
 uniform int uChannel;
 uniform float uTexel;
 uniform float uNormalStrength;
 ${LEAF_COMMON}
+${PALETTE_GLSL}
 
 void leafSurf(vec2 uv, out vec3 alb, out float a, out float h, out float rough, out float trans){
   vec2 g = uv * ${ATLAS_N}.0;
@@ -353,14 +394,14 @@ void leafSurf(vec2 uv, out vec3 alb, out float a, out float h, out float rough, 
    * comparison because there is nothing warm left for them to be. Real
    * understory foliage is a restrained blue-green — the yellow-greens belong
    * to new flushes and to the canopy where there is light to make them. */
-  vec3 deep = vec3(0.034, 0.077, 0.042);
-  vec3 midC = vec3(0.070, 0.137, 0.072);
-  vec3 lite = vec3(0.126, 0.188, 0.104);
+  vec3 deep = LEAF_DEEP;
+  vec3 midC = LEAF_MID;
+  vec3 lite = LEAF_LITE;
   vec3 body = mix(deep, midC, mott);
   body = mix(body, lite, sstep(0.62, 1.0, mott) * 0.55);
   vec3 col = body;
-  col = mix(col, vec3(0.155, 0.184, 0.082), vein * 0.50 + retic * 0.14);
-  col = mix(col, vec3(0.186, 0.206, 0.102), midrib * 0.70);
+  col = mix(col, LEAF_VEIN, vein * 0.50 + retic * 0.14);
+  col = mix(col, LEAF_RIB, midrib * 0.70);
 
   /* The margin, and getting this wrong was half of the ringed-leaf problem.
    *
@@ -374,19 +415,19 @@ void leafSurf(vec2 uv, out vec3 alb, out float a, out float h, out float rough, 
    * than the body rather than darker. The vein sits deliberately inside the
    * alpha ramp at r = 0.93 so no part of it is ever in a texel that filtering
    * can smear outward past the silhouette. */
-  col = mix(col, vec3(0.058, 0.094, 0.046),
+  col = mix(col, LEAF_EDGE,
             sstep(0.84, 0.905, r) * sstep(0.945, 0.900, r) * 0.55);
-  col = mix(col, vec3(0.158, 0.182, 0.096),
+  col = mix(col, LEAF_PALE,
             sstep(0.56, 0.83, r) * sstep(0.92, 0.82, r) * 0.30);
   /* Chlorosis: the yellowing halo that spreads well beyond the dead tissue.
    * Held down in chroma on purpose. These blotches are the only warm marks in
    * an otherwise entirely green frame, so the eye finds every one of them, and
    * at full saturation a stand of understory leaves reads as a scatter of
    * orange stickers rather than as damage. */
-  col = mix(col, vec3(0.228, 0.208, 0.100), sstep(0.0, 0.22, dmg + bite) * 0.30);
-  col = mix(col, vec3(0.130, 0.084, 0.044), necro * 0.95);  // brown where chewed
-  col = mix(col, vec3(0.124, 0.142, 0.108), epi * 0.36);    // grey-green crust
-  col = mix(col, vec3(0.086, 0.100, 0.062), epiSpot * 0.55);
+  col = mix(col, LEAF_CHLO, sstep(0.0, 0.22, dmg + bite) * 0.30);
+  col = mix(col, LEAF_NECR, necro * 0.95);  // brown where chewed
+  col = mix(col, LEAF_EPI, epi * 0.36);     // crust
+  col = mix(col, LEAF_EPIS, epiSpot * 0.55);
   /* The pucker shows in the albedo as well as the normal, faintly. Relief that
    * exists only in the normal map disappears the moment a surface faces away
    * from every light, which under this canopy is most of them — and a blade
@@ -395,7 +436,7 @@ void leafSurf(vec2 uv, out vec3 alb, out float a, out float h, out float rough, 
   col *= 1.0 + crinkle * 0.055 + (retic - 0.25) * 0.05;
   // Roughly a third of the individuals carry a pale flush of new growth.
   float flush = step(0.66, fract(seed * 0.371));
-  col = mix(col, vec3(0.174, 0.164, 0.100), sstep(0.78, 1.0, t) * 0.24 * flush);
+  col = mix(col, LEAF_FLUSH, sstep(0.78, 1.0, t) * 0.24 * flush);
 
   /* Colour outside the blade is not "don't care", and assuming it was is what
    * put a hard pale rim on every leaf in the frame.
@@ -494,6 +535,13 @@ void main(){
   }
 }
 `;
+}
+
+/** The leaf atlas fragment for a scenario palette. */
+export function leafFrag(palette = 'jungle') {
+  const name = Object.hasOwn(LEAF_PALETTES, palette) ? palette : 'jungle';
+  return leafFragSource(LEAF_PALETTES[name]);
+}
 
 /* Bark.
  *

--- a/src/world/ruins.js
+++ b/src/world/ruins.js
@@ -1560,6 +1560,23 @@ export class Ruins {
     }
   }
 
+  dispose() {
+    if (this._disposed) return;
+    const geometries = new Set();
+    this.root.traverse((o) => { if (o.geometry) geometries.add(o.geometry); });
+    for (const g of geometries) g.dispose();
+    const disposeMap = (map) => {
+      if (!map) return;
+      if (map.userData?.rt) map.userData.rt.dispose();
+      else map.dispose?.();
+    };
+    for (const map of Object.values(this.material?.userData?.maps || {})) disposeMap(map);
+    this.material?.dispose();
+    this.root.remove(...this.root.children);
+    this.cells.length = 0;
+    this._disposed = true;
+  }
+
   stats() {
     return { blocks: this.blockCount, meshes: this.cells.length, tris: this.triangles };
   }

--- a/src/world/terrain.js
+++ b/src/world/terrain.js
@@ -17,7 +17,7 @@
 import * as THREE from 'three';
 import { Noise2D, clamp, smoothstep, lerp } from './noise.js';
 import { CLIFF_Z } from './path.js';
-import { DIRT, LITTER, ROCK, MACRO } from './groundTex.js';
+import { DIRT, LITTER, ROCK, MACRO, FLOAM, FALLEN, COOLROCK } from './groundTex.js';
 import { bakeSurface } from '../gfx/bake.js';
 import { SSTEP } from '../gfx/glsl.js';
 import {
@@ -589,6 +589,15 @@ export class Terrain {
     g.computeBoundingSphere();
     return g;
   }
+
+  dispose() {
+    if (!this.group) return;
+    const geometries = new Set();
+    this.group.traverse((o) => { if (o.geometry) geometries.add(o.geometry); });
+    for (const g of geometries) g.dispose();
+    this.group.remove(...this.group.children);
+    this.group = null;
+  }
 }
 
 /* ── material ──────────────────────────────────────────────────────────────
@@ -597,10 +606,19 @@ export class Terrain {
  * shadow, fog and tone-mapping chunks working, which is a very large amount of
  * correct code to not have to reimplement in order to blend three textures.
  */
-export function makeTerrainMaterial(renderer) {
-  const dirt = bakeSurface(renderer, DIRT, { size: 1024, normalStrength: 2.6 });
-  const litter = bakeSurface(renderer, LITTER, { size: 1024, normalStrength: 4.6 });
-  const rock = bakeSurface(renderer, ROCK, { size: 1024, normalStrength: 3.0 });
+/* The three ground surfaces per biome. `jungle` is the original trio; the
+ * forest set is the same construction with a temperate palette. The splat
+ * weights, the biplanar sampling and the wet/moss treatment are shared. */
+const GROUND_SETS = {
+  jungle: { dirt: DIRT, litter: LITTER, rock: ROCK },
+  forest: { dirt: FLOAM, litter: FALLEN, rock: COOLROCK },
+};
+
+export function makeTerrainMaterial(renderer, set = 'jungle') {
+  const S = Object.hasOwn(GROUND_SETS, set) ? GROUND_SETS[set] : GROUND_SETS.jungle;
+  const dirt = bakeSurface(renderer, S.dirt, { size: 1024, normalStrength: 2.6 });
+  const litter = bakeSurface(renderer, S.litter, { size: 1024, normalStrength: 4.6 });
+  const rock = bakeSurface(renderer, S.rock, { size: 1024, normalStrength: 3.0 });
   const macro = bakeSurface(renderer, MACRO, { size: 256, normal: false, orm: false });
 
   const mat = new THREE.MeshStandardMaterial({

--- a/src/world/vegetation.js
+++ b/src/world/vegetation.js
@@ -30,7 +30,7 @@
  */
 import * as THREE from 'three';
 import { bakeImage, bakeSurface } from '../gfx/bake.js';
-import { LEAF_FRAG, BARK } from './plantTex.js';
+import { leafFrag, BARK } from './plantTex.js';
 import { makeRng, fern, broadleaf, palm, sprig, tussock, vine, tree, canopyPatch, thicket, sapling, log, deadVine, litterMat, rootRun } from './plants.js';
 import { BOUNDS } from './terrain.js';
 import { standingWater } from './spillway.js';
@@ -558,7 +558,7 @@ export class Vegetation {
    *   density every real ruin has along them.
    * @param {import('../player/collision.js').CollisionWorld} [collision]
    */
-  constructor(renderer, terrain, trail, seed = 7717, ruins = null, collision = null) {
+  constructor(renderer, terrain, trail, seed = 7717, ruins = null, collision = null, opts = {}) {
     this.renderer = renderer;
     this.terrain = terrain;
     this.trail = trail;
@@ -568,6 +568,24 @@ export class Vegetation {
     this.root.name = 'vegetation';
     this.time = 0;
     this.cells = [];
+
+    /* Scenario knobs. `palette` picks which leaf atlas bakes; `tuning` carries
+     * the species weights, per-instance tint and bark tint. Defaults reproduce
+     * the original jungle exactly. */
+    const tuning = opts?.tuning && typeof opts.tuning === 'object' ? opts.tuning : {};
+    const defaults = {
+      palmScale: 1, broadleafScale: 1, conifer: false,
+      tint: { rMul: 0.90, rSway: 0.16, bMul: 0.84, bSway: 0.20 },
+      senescent: { yellow: 0.93, olive: 0.84 },
+      woodTint: 0xffffff,
+    };
+    this.palette = typeof opts?.palette === 'string' ? opts.palette : 'jungle';
+    this.tuning = {
+      ...defaults,
+      ...tuning,
+      tint: { ...defaults.tint, ...(tuning.tint || {}) },
+      senescent: { ...defaults.senescent, ...(tuning.senescent || {}) },
+    };
 
     this.uniforms = {
       uTime: { value: 0 },
@@ -607,7 +625,7 @@ export class Vegetation {
     };
     const shot = (ch, colorSpace, coverageMips = 0) => {
       uniforms.uChannel.value = ch;
-      return bakeImage(renderer, LEAF_FRAG, { size, uniforms, colorSpace, coverageMips });
+      return bakeImage(renderer, leafFrag(this.palette), { size, uniforms, colorSpace, coverageMips });
     };
     /* Only the albedo gets a hand-built mip chain, because only its alpha is
      * ever tested. The other two are sampled, not thresholded, so the GPU's
@@ -673,6 +691,9 @@ export class Vegetation {
     this.leafMat = patchWind(leaf, this.uniforms, { transmission: true });
 
     const wood = new THREE.MeshStandardMaterial({
+      // A bark tint per biome: tropical bark is pale on purpose, and temperate
+      // bark reads wrong at that value, so the forest coats it darker.
+      color: this.tuning.woodTint,
       map: this.barkTex.map,
       normalMap: this.barkTex.normalMap,
       roughnessMap: this.barkTex.ormMap,
@@ -1028,7 +1049,8 @@ export class Vegetation {
       if (c.stone) return 0;
       if (!bank(c, 2.0, 62)) return 0;
       if (c.slope > 0.75) return 0;
-      return 0.42 * edgeLight(c.dist) * wallFoot(c, 0.35) * rooting(c, 0.92, 0.72);
+      return 0.42 * edgeLight(c.dist) * wallFoot(c, 0.35) * rooting(c, 0.92, 0.72)
+           * this.tuning.palmScale;
     }, (c) => {
       // Palms come up in cohorts under a parent, so a clump centre is where
       // the tall ones are and the rim is all suckers.
@@ -1044,7 +1066,8 @@ export class Vegetation {
       if (!bank(c, 1.0, 48)) return 0;
       if (c.slope > 0.85) return 0;
       return 0.62 * edgeLight(c.dist) * (0.7 + 0.5 * c.wet)
-           * wallFoot(c, 0.55) * (c.stone ? 0.28 : 1) * rooting(c, 0.85, 0.58);
+           * wallFoot(c, 0.55) * (c.stone ? 0.28 : 1) * rooting(c, 0.85, 0.58)
+           * this.tuning.broadleafScale;
     }, (c) => {
       const s = 0.58 + c.rng() * 0.72 + c.dens * 0.40;
       return {
@@ -1445,14 +1468,18 @@ export class Vegetation {
        * changed hue as it crossed the switch radius would turn an invisible
        * change of resolution into an obvious one. */
       const cols = [];
+      const T = this.tuning.tint;
+      const S = this.tuning.senescent;
       for (let i = 0; i < b.items.length; i++) {
         const v = (0.60 + rng() * 0.46) * shade;
         /* Held closer to neutral than it was. The chroma spread here is
          * multiplied by an already yellow-green atlas, so its warm end was
          * landing on screen as cream — which is what put the pale, almost
-         * unrelated-looking leaves through the middle of the frame. */
+         * unrelated-looking leaves through the middle of the frame. The
+         * scenario tuning nudges the tint warm (forest) or leaves it as-is
+         * (jungle). */
         const col = new THREE.Color(
-          v * (0.90 + rng() * 0.16), v, v * (0.84 + rng() * 0.20));
+          v * (T.rMul + rng() * T.rSway), v, v * (T.bMul + rng() * T.bSway));
         /* Roughly one plant in nine is dying, and it is the most valuable
          * one in the frame. Uniform health is a strong CG tell: a real
          * understory always has senescing fronds going yellow and dead ones
@@ -1462,8 +1489,8 @@ export class Vegetation {
          * plants read as separate objects painted a different colour rather
          * than as the same species in worse condition. */
         const age = rng();
-        if (age > 0.93) col.lerp(new THREE.Color(0.58, 0.47, 0.28), 0.22 + rng() * 0.22);
-        else if (age > 0.84) col.lerp(new THREE.Color(0.60, 0.57, 0.38), 0.14 + rng() * 0.14);
+        if (age > S.yellow) col.lerp(new THREE.Color(0.58, 0.47, 0.28), 0.22 + rng() * 0.22);
+        else if (age > S.olive) col.lerp(new THREE.Color(0.60, 0.57, 0.38), 0.14 + rng() * 0.14);
         cols.push(col);
       }
 
@@ -1614,6 +1641,40 @@ export class Vegetation {
       }
     }
     return { meshes: this.cells.length, instances: n, tris: Math.round(tris) };
+  }
+
+  dispose() {
+    if (this._disposed) return;
+
+    const geometries = new Set();
+    this.root.traverse((o) => { if (o.geometry) geometries.add(o.geometry); });
+    for (const variants of Object.values(this.species || {})) {
+      for (const variant of variants) {
+        for (const lod of [variant.hi, variant.lo]) {
+          if (lod?.leaf) geometries.add(lod.leaf);
+          if (lod?.wood) geometries.add(lod.wood);
+        }
+      }
+    }
+    for (const g of geometries) g.dispose();
+
+    for (const m of [this.leafMat, this.woodMat, this.leafDepth, this.woodDepth]) {
+      m?.dispose();
+    }
+    const disposeTexture = (t) => {
+      if (!t) return;
+      if (t.userData?.rt) t.userData.rt.dispose();
+      else t.dispose?.();
+    };
+    disposeTexture(this.leafMap);
+    disposeTexture(this.leafNrm);
+    disposeTexture(this.leafAux);
+    this.barkTex?.dispose?.();
+
+    this.root.remove(...this.root.children);
+    this.cells.length = 0;
+    this.species = null;
+    this._disposed = true;
   }
 }
 

--- a/src/world/water.js
+++ b/src/world/water.js
@@ -149,6 +149,7 @@ uniform vec3 uDeep;
 uniform vec3 uShallow;
 uniform vec3 uSkyRefl;
 uniform vec3 uBankRefl;
+uniform vec3 uShimmer;
 uniform vec3 uFoamCol;
 uniform float uWaterDbg;
 varying vec3 vWorldW;
@@ -486,6 +487,13 @@ export class Water {
            * suggestion of collected bubbles, not a kerb. */
           float shore = sstep(0.09, 0.01, gWaterDepth) * sstep(0.62, 0.88, fm.x) * 0.22;
           float foam = clamp(max(carried, shore) * (0.62 + 0.38 * fmFine.y), 0.0, 1.0);
+          /* Fast shallow reaches also break on their crests. Keep this
+           * narrow and speed-gated: it is a riffle crest, not a second white
+           * texture over the whole river. */
+          float riffle = sstep(1.15, 3.0, gWaterSpd);
+          float crestFoam = sstep(0.76, 0.96, gRip) * riffle
+                          * (0.12 + 0.20 * fmFine.y);
+          foam = max(foam, crestFoam);
           // Directly under the fall it is not foam but aerated water, and
           // that has to go nearly opaque or the plunge point is a hole.
           foam = max(foam, sstep(0.80, 0.95, vAgitW));
@@ -567,6 +575,17 @@ export class Water {
           float still = 1.0 - min(1.0, gWaterSpd * 0.42);
           diffuseColor.rgb = mix(diffuseColor.rgb, refl,
                                  fres * 0.72 * (1.0 - foam) * still);
+
+          /* A small bounded glint keeps the pool readable when the canopy
+           * reflection is dark. It is below the foam value: a real ripple
+           * catches a broken highlight, it does not turn the basin into a
+           * mirror. */
+          float crest = sstep(0.70, 0.96, gRip);
+          float glint = crest * (0.24 + 0.76 * fres) * (1.0 - foam)
+                      * (0.32 + 0.68 * min(1.0, gWaterDepth * 0.42));
+          glint *= 0.72 + 0.28 * sin(gAlong * 0.72 - uTime * 0.85
+                                      + gAcross * 0.11);
+          diffuseColor.rgb += uShimmer * glint * 0.16;
 
           // The waterline itself. Feathered over the last few centimetres so
           // the edge wanders with the ripple instead of cutting the bed on a
@@ -710,6 +729,10 @@ export class Water {
         // The far bank, the cliff and the closed forest behind them, which is
         // what a nearly horizontal bounce off this pool actually finds.
         uBankRefl: { value: new THREE.Color(0x151a15) },
+        /* A desaturated skylight tint for moving crest highlights. It is not a
+         * second light: the small additive term is bounded in the shader and
+         * exists only to keep ripples legible in the shaded pool. */
+        uShimmer: { value: new THREE.Color(0x718f84) },
         /* Grey, not white, and this was the last thing wrong with the pool.
          *
          * Foam reads as white because it is the brightest thing in a river,
@@ -971,7 +994,7 @@ export class Water {
   _buildBoil() {
     // Dense enough to carry the churn's relief. Still one draw call, and the
     // triangle count is noise next to the two and a half million in frame.
-    const NR = 30, NA = 96, R = 7.4;
+    const NR = 38, NA = 112, R = 7.4;
     const W = NA + 1, H = NR + 1;
     const P = new Float32Array(W * H * 3);
     const pol = new Float32Array(W * H * 2);
@@ -1012,7 +1035,7 @@ export class Water {
     const m = new THREE.MeshStandardMaterial({
       color: 0xffffff, roughness: 0.4, metalness: 0.0,
       transparent: true, depthWrite: false, side: THREE.DoubleSide,
-      envMapIntensity: 1.0,
+      envMapIntensity: 0.58,
     });
 
     /* The surface, written once and used three times — for the height, for
@@ -1064,7 +1087,7 @@ export class Water {
          * like once it was made opaque. What a boil actually presents is a
          * *broken* surface barely raised above the pool, so the height comes
          * down and most of what is left is the lumps below. */
-        float dome = 0.62 * exp(-r * r / 7.0);
+        float dome = 0.38 * exp(-r * r / 7.0);
         /* Lumps from the noise field rather than from harmonics in the angle,
          * and the reason is spatial frequency near the pole.
          *
@@ -1080,19 +1103,25 @@ export class Water {
          * to zero in the middle of the churn. That collapse is what faceted the
          * first version of this. */
         float ar = a * min(4.0, 0.9 + r * 0.8);
-        float lump = 0.26 * exp(-r * r / 9.0)
+        float lump = 0.14 * exp(-r * r / 9.0)
           * (sin(ar + t * 2.1 + r * 1.3) * sin(r * 1.7 - t * 2.6)
            + 0.6 * sin(ar * 1.6 - t * 1.5) * cos(r * 2.3 - t * 3.1));
+        /* The baked field contributes a broad, non-periodic bias to the
+         * crown. It is intentionally low amplitude: foam coverage supplies
+         * the fine breakup; the vertex field should only stop the ring from
+         * becoming a perfectly repeating set of radial lobes. */
+        lump += 0.075 * exp(-r * r / 10.0) * (n - 0.5)
+              + 0.045 * exp(-r * r / 13.0) * (n2 - 0.5);
         /* Waves radiating out, and the phase has to be r - ct with c
          * positive or the rings travel inward, which reads as a drain. The
          * amplitude decays with radius twice over: once because a circular
          * wave spreads its energy round a growing circumference, and once
          * because it damps. */
-        float ring = 0.26 * amp * exp(-r * 0.26) / sqrt(1.0 + r)
+        float ring = 0.18 * amp * exp(-r * 0.26) / sqrt(1.0 + r)
           * sin((r + wob) * 2.05 - t * 3.4);
-        ring += 0.11 * amp * exp(-r * 0.20) / sqrt(1.0 + r)
+        ring += 0.075 * amp * exp(-r * 0.20) / sqrt(1.0 + r)
           * sin((r - wob * 1.7) * 1.31 - t * 2.15 + a * 0.8);
-        float swell = 0.055 * sin(r * 0.7 - t * 1.35 + a * 1.5);
+        float swell = 0.035 * sin(r * 0.7 - t * 1.35 + a * 1.5);
         /* And all of it goes to nothing before the mesh does. The disc has an
          * outline and the water does not, so anything still moving when the
          * rim arrives draws that outline for you — a raised elliptical table
@@ -1108,7 +1137,7 @@ export class Water {
         // Held below the curtain's own white. The churn is lit by the same
         // skylight and is no brighter than the sheet feeding it; brighter and
         // it separates from the fall and reads as a foreign object.
-        uWhite: { value: new THREE.Color(0xaeb6b1) },
+        uWhite: { value: new THREE.Color(0x9aa6a2) },
         // Less green. The impact of a fall is grey-white water with air in it,
         // and a teal base showing between the bubbles was most of why the
         // footprint read as pond rather than as churn.
@@ -1213,12 +1242,21 @@ export class Water {
            * only once it is outside the churn, and the modulation by the map
            * has to be applied to the rafts and not to the core: multiplying the
            * core by a noise field is what turned it into speckle. */
-          float cov = sstep(5.2, 3.0, r);
+          float cov = sstep(5.2, 3.0, r) * (0.72 + 0.28 * f1.g);
           float ring = exp(-pow((r - 3.6 - 0.55 * sin(uTime * 0.7)
                                  - 0.8 * sin(a * 2.0 + uTime * 0.3)) / 2.1, 2.0));
           float rafts = sstep(7.2, 2.2, r) * (0.25 + 1.5 * f1.g * (0.4 + 1.2 * f2.r));
+          /* The impact leaves a short foam wake in the downstream direction.
+           * It is wider at the crown and narrows as it is carried away, which
+           * joins the local boil to the current instead of leaving an isolated
+           * white disc under the curtain. */
+          float downstream = max(0.0, xz.y);
+          float wake = sstep(0.35, 1.1, downstream)
+                     * exp(-downstream * 0.42)
+                     * exp(-xz.x * xz.x / 4.2)
+                     * (0.30 + 0.70 * f1.g);
           cov = clamp(max(cov, max(ring * (0.62 + 0.42 * f1.r),
-                                   rafts * (0.55 + 0.6 * f1.r))), 0.0, 1.0);
+                                   max(rafts * (0.55 + 0.6 * f1.r), wake))), 0.0, 1.0);
 
           /* Bubbles read as light *between* dark water, so the white goes on
            * top of the deep colour rather than the surface being tinted. */
@@ -1235,7 +1273,7 @@ export class Water {
           // as a hard-edged opaque anything: the shape you see is the shape of
           // the primitive.
           diffuseColor.a = max(diffuseColor.a,
-                               sstep(6.0, 2.4, r) * (0.55 + 0.62 * f1.r));
+                               sstep(6.0, 2.4, r) * (0.34 + 0.44 * f1.r));
           gFoam = cov;
         `)
         .replace('#include <roughnessmap_fragment>', /* glsl */ `
@@ -1268,7 +1306,10 @@ export class Water {
       transparent: true,
       depthWrite: false,
       side: THREE.DoubleSide,
-      envMapIntensity: 1.5,
+      /* The curtain is already lit by the explicit aeration/scatter terms
+       * below. A strong environment lobe flattens the whole sheet into a
+       * white panel before those terms can show the packet structure. */
+      envMapIntensity: 0.65,
     });
 
     m.onBeforeCompile = (sh) => {
@@ -1366,7 +1407,12 @@ export class Water {
            * polished wood rather than as water. The lateral tearing is the
            * geometry's job; the texture only has to avoid contradicting it. */
           float shear = vCol * (0.05 + 0.17 * f);
-          vec2 uv = vec2(vAcross * 1.35 + shear, parcel * 0.34);
+          /* A pair of incommensurate bends keeps the filaments from staying
+           * parallel for the whole drop. Geometry supplies the large tear;
+           * this supplies the smaller packet-scale wobble between columns. */
+          float bend = 0.075 * sin(parcel * 5.2 + vAcross * 8.7)
+                     + 0.035 * sin(parcel * 11.1 - vAcross * 17.0 + 1.7);
+          vec2 uv = vec2(vAcross * 1.35 + shear + bend, parcel * 0.34);
           vec4 st = texture2D(tStrands, uv);
           // A second, slower read for the surges travelling down the sheet.
           vec4 sg = texture2D(tStrands, vec2(uv.x * 0.6 + 0.2, parcel * 0.14 + 0.5));
@@ -1446,8 +1492,17 @@ export class Water {
            * centreline and the fringe by the fine map, rather than the whole
            * thing being faded by one scalar. */
           float core = sstep(0.86, 0.30, abs(vAcross));
-          float aBurst = core * (0.80 + 0.20 * sf.b)
-                       + 0.55 * sf.r * (0.30 + 0.70 * rope);
+          /* The lower sheet is turbulent, but it is not a solid rectangular
+           * panel. A packet mask made from the slow surge, fine breakup and a
+           * low-amplitude diagonal wave leaves darker channels through the
+           * core, so the cliff and the water behind it remain visible. */
+          float packet = sstep(0.28, 0.76,
+                         0.50 * sg.g + 0.30 * sf.r
+                         + 0.20 * (0.5 + 0.5 * sin(parcel * 5.1
+                                                   + vAcross * 11.0 + sg.b * 6.2831)));
+          float aBurst = core * (0.34 + 0.52 * packet)
+                       + 0.34 * sf.r * (0.22 + 0.78 * rope);
+          aBurst *= 0.82 + 0.18 * sg.g;
           a = mix(a, clamp(aBurst, 0.0, 1.0), burst);
 
           /* The limbs, which is the term the sheet was missing and the reason
@@ -1492,8 +1547,8 @@ export class Water {
            * third of the way down — whitest at the top, thinning to grey —
            * which is the inversion the critique caught. This one starts at
            * nothing and does not reach full until the bottom. */
-          gAer = clamp(sstep(0.03, 0.72, f) * (0.78 + 0.34 * sg.g)
-                       + 0.14 * strand * torn, 0.0, 1.0);
+          gAer = clamp(sstep(0.03, 0.82, f) * (0.65 + 0.24 * sg.g)
+                       + 0.12 * strand * torn, 0.0, 1.0);
           /* And the value it maps to keeps its structure, which is the other
            * half of the saturation problem.
            *
@@ -1505,7 +1560,7 @@ export class Water {
            * carries most of that variation and the surge map the rest, and the
            * ceiling stays short of the white so there is somewhere for a lit
            * highlight to go without clipping. */
-          float val = gAer * (0.34 + 0.50 * rope + 0.22 * sg.g);
+          float val = gAer * (0.26 + 0.42 * rope + 0.18 * sg.g + 0.12 * packet);
           // The limbs are thinner water and therefore darker as well as more
           // transparent; without this they are pale and the sheet keeps its
           // hard edge in value even after it has lost it in alpha.
@@ -1546,7 +1601,7 @@ export class Water {
              * it, which is most of the day here — and it was doing so
              * uniformly, so it erased the structure the diffuse had. */
             totalEmissiveRadiance += directionalLights[0].color
-              * pow(fwd, 5.0) * gAer * (0.10 + 0.30 * gRope) * diffuseColor.a;
+              * pow(fwd, 5.0) * gAer * (0.08 + 0.22 * gRope) * diffuseColor.a;
           #endif
           /* And a floor under it that owes nothing to the sun.
            *
@@ -2071,7 +2126,7 @@ export class Water {
       this.spray = null;
     }
     this._buildSpray();
-    if (this.spray) this.spray.renderOrder = 13;
+    if (this.spray) this.spray.renderOrder = 14;
   }
 
   update(dt, camera, sunDir, sunColor, hemiColor, sunIntensity = 1) {
@@ -2109,9 +2164,26 @@ export class Water {
   }
 
   dispose() {
-    for (const t of Object.values(this.tex)) t.dispose?.();
-    this.surfaceMat.dispose();
-    this.curtainMat.dispose();
-    this.spray?.material.dispose();
+    if (this._disposed) return;
+    const disposeTexture = (t) => {
+      if (!t) return;
+      if (t.userData?.rt) t.userData.rt.dispose();
+      else t.dispose?.();
+    };
+    for (const t of Object.values(this.tex)) disposeTexture(t);
+
+    const geometries = new Set();
+    const materials = new Set(this.materials || []);
+    this.root.traverse((o) => {
+      if (o.geometry) geometries.add(o.geometry);
+      if (o.material) {
+        for (const m of (Array.isArray(o.material) ? o.material : [o.material])) materials.add(m);
+      }
+    });
+    for (const g of geometries) g.dispose();
+    for (const m of materials) m?.dispose?.();
+
+    this.root.remove(...this.root.children);
+    this._disposed = true;
   }
 }

--- a/test/scenario.test.mjs
+++ b/test/scenario.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { SCENARIOS, explicitScenarioFor, scenarioFor } from '../src/scenario.js';
+import {
+  DEFAULT_LEVELS, LEVELS, resetLevelOverrides, setLevelOverrides,
+} from '../src/audio/score.js';
+
+test('scenarioFor accepts documented forms and rejects prototype keys', () => {
+  assert.equal(scenarioFor(''), 'jungle');
+  assert.equal(scenarioFor('#forest'), 'forest');
+  assert.equal(scenarioFor('#forest&tier=low'), 'forest');
+  assert.equal(scenarioFor('#scenario=forest&manual'), 'forest');
+  assert.equal(scenarioFor('#constructor'), 'jungle');
+  assert.equal(scenarioFor('#scenario=toString'), 'jungle');
+  assert.equal(explicitScenarioFor(''), null);
+  assert.equal(explicitScenarioFor('#scenario=forest'), 'forest');
+  assert.equal(explicitScenarioFor('#constructor'), null);
+  assert.ok(Object.hasOwn(SCENARIOS, scenarioFor('#forest')));
+});
+
+test('score overrides are finite, own properties and resettable', () => {
+  resetLevelOverrides();
+  setLevelOverrides({ cicada: -33, constructor: 12, birds: NaN });
+  assert.equal(LEVELS.cicada, -33);
+  assert.equal(LEVELS.birds, DEFAULT_LEVELS.birds);
+  assert.equal(Object.hasOwn(LEVELS, 'constructor'), false);
+  resetLevelOverrides();
+  assert.deepEqual(LEVELS, DEFAULT_LEVELS);
+});

--- a/tools/audio-live.mjs
+++ b/tools/audio-live.mjs
@@ -42,7 +42,7 @@ function note(ok, label, detail) {
   console.log(`  ${ok ? '✓' : '·'} ${label}${detail ? '  — ' + detail : ''}`);
 }
 
-await run({ width: 960, height: 540, hash: 'manual&tier=high' }, async ({ page }) => {
+const liveRun = await run({ width: 960, height: 540, hash: 'manual&tier=high' }, async ({ page }) => {
   /* Installed before anything is asked of the audio system. An unhandled
    * rejection is the exact shape a failed unlock takes — unlock() is async and
    * is called from an event listener that cannot await it — so catching them
@@ -272,6 +272,8 @@ await run({ width: 960, height: 540, hash: 'manual&tier=high' }, async ({ page }
   const rejects = await page.evaluate(() => window.__rejects);
   expect(rejects.length === 0, 'no unhandled promise rejections', rejects.join(' | ').slice(0, 200));
 });
+
+if (!liveRun.ok) fails.push('browser probe');
 
 console.log(fails.length ? `\n✗ ${fails.length} failed: ${fails.join('; ')}` : '\n✓ all live audio checks passed');
 finish(fails.length ? 1 : (process.exitCode || 0));

--- a/tools/audio.mjs
+++ b/tools/audio.mjs
@@ -9,7 +9,8 @@
  *
  *   node tools/audio.mjs all                       # every demo + smoke test
  *   node tools/audio.mjs layers                    # each layer in isolation
- *   node tools/audio.mjs mix --t 0.55 [--secs 20]  # full mix at a trail point
+ *   node tools/audio.mjs mix --t 0.55 [--secs 20] [--scenario forest]
+ *                                                   # full mix at a trail point
  *   node tools/audio.mjs demo layer-falls-near     # a single named demo
  *   node tools/audio.mjs stats shots/audio/x.wav   # re-analyse an existing file
  *   node tools/audio.mjs smoke                     # engine.js on a mock graph
@@ -24,6 +25,8 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { renderScene, renderDemo, DEMOS } from '../src/audio/mix.js';
 import { Ambience } from '../src/audio/engine.js';
 import { bakeBank, bankJobs, bankBytes, DEFAULT_SEED } from '../src/audio/bank.js';
+import { SCENARIOS } from '../src/scenario.js';
+import { resetLevelOverrides, setLevelOverrides } from '../src/audio/score.js';
 import {
   WALK_SPEED, JOG_SPEED, JUMP_SPEED, gaitCycleRate, stepRate,
 } from '../src/player/gait.js';
@@ -31,6 +34,8 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = path.join(ROOT, 'shots', 'audio');
 const SR = 48000;
+let ACTIVE_SCENARIO = 'jungle';
+const outputSuffix = () => ACTIVE_SCENARIO === 'jungle' ? '' : `-${ACTIVE_SCENARIO}`;
 
 /* ------------------------------------------------------------------ WAV */
 
@@ -319,17 +324,24 @@ function saveDemo(name) {
   const t0 = performance.now();
   const { L, R } = renderDemo(name, SR);
   const ms = performance.now() - t0;
-  const file = path.join(OUT_DIR, `${name}.wav`);
+  const file = path.join(OUT_DIR, `${name}${outputSuffix()}.wav`);
   writeWav(file, SR, L, R);
-  console.log(`${name}.wav  (rendered in ${(ms / 1000).toFixed(1)}s, ` +
+  console.log(`${path.basename(file)}  (rendered in ${(ms / 1000).toFixed(1)}s, ` +
     `${(L.length / SR / (ms / 1000)).toFixed(1)}x realtime)`);
-  printStats(name, analyse(SR, L, R));
+  printStats(path.basename(file), analyse(SR, L, R));
 }
 
 async function main() {
   const args = process.argv.slice(2);
   const cmd = args[0] || 'all';
   const flag = (k, dv) => { const i = args.indexOf('--' + k); return i < 0 ? dv : args[i + 1]; };
+  const scenarioName = flag('scenario', 'jungle') || 'jungle';
+  if (!Object.hasOwn(SCENARIOS, scenarioName)) {
+    throw new Error(`unknown scenario '${scenarioName}' — one of: ${Object.keys(SCENARIOS).join(', ')}`);
+  }
+  ACTIVE_SCENARIO = scenarioName;
+  resetLevelOverrides();
+  if (SCENARIOS[scenarioName].audio) setLevelOverrides(SCENARIOS[scenarioName].audio);
   fs.mkdirSync(OUT_DIR, { recursive: true });
 
   if (cmd === 'stats') {
@@ -344,7 +356,7 @@ async function main() {
   } else if (cmd === 'mix') {
     const t = +flag('t', 0.15), secs = +flag('secs', 20);
     const { L, R } = renderScene(SR, secs, { t0: t, walk: !args.includes('--static'), birdDensity: 0.25 });
-    const file = path.join(OUT_DIR, `mix-t${String(t).replace('.', '')}.wav`);
+    const file = path.join(OUT_DIR, `mix-t${String(t).replace('.', '')}${outputSuffix()}.wav`);
     writeWav(file, SR, L, R);
     printStats(path.basename(file), analyse(SR, L, R));
   } else if (cmd === 'layers') {
@@ -359,11 +371,11 @@ async function main() {
     console.log('');
     await smoke();
   } else {
-    console.error('usage: node tools/audio.mjs [all|layers|mix|demo|stats|smoke|jobs]');
+    console.error('usage: node tools/audio.mjs [all|layers|mix|demo|stats|smoke|jobs] [--scenario jungle|forest]');
     process.exit(1);
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((e) => { console.error(e); process.exit(1); });
 }

--- a/tools/check.mjs
+++ b/tools/check.mjs
@@ -45,7 +45,7 @@ export function check() {
  * printed nothing and exited zero — a checker that always passes is worse than
  * no checker, and it stayed unnoticed because the harness calls check()
  * itself. */
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const bad = check();
   if (bad.length) { console.error('✗ parse errors:\n' + bad.join('\n')); process.exit(1); }
   console.log('✓ all sources parse');

--- a/tools/harness.mjs
+++ b/tools/harness.mjs
@@ -67,15 +67,19 @@ const CPU_ARGS = [
 ];
 
 export function serve(root = ROOT) {
+  const base = path.resolve(root);
+  const inside = (f) => f === base || f.startsWith(base + path.sep);
   const TYPES = {
     '.html': 'text/html; charset=utf-8', '.js': 'text/javascript',
     '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json',
     '.png': 'image/png',
   };
   return http.createServer((rq, rs) => {
-    const rel = decodeURI(rq.url.split('?')[0].split('#')[0]);
-    const f = path.join(root, rel === '/' ? 'index.html' : rel);
-    if (!f.startsWith(root)) { rs.writeHead(403); return rs.end(); }
+    let rel;
+    try { rel = decodeURIComponent(rq.url.split('?')[0].split('#')[0]); }
+    catch (_) { rs.writeHead(400); return rs.end('bad request'); }
+    const f = path.resolve(base, '.' + (rel === '/' ? '/index.html' : rel));
+    if (!inside(f)) { rs.writeHead(403); return rs.end(); }
     fs.readFile(f, (e, d) => {
       if (e) { rs.writeHead(404); return rs.end('not found'); }
       rs.writeHead(200, {
@@ -128,7 +132,7 @@ export async function run(opts, body) {
   if (bad.length) {
     console.error('✗ parse errors — not launching a browser:\n' + bad.join('\n'));
     process.exitCode = 1;
-    return { errs: bad, gl: null };
+    return { errs: bad, gl: null, ok: false };
   }
 
   let srv = null;
@@ -201,5 +205,5 @@ export async function run(opts, body) {
     [...new Set(errs)].slice(0, 15).forEach(e => console.log(' ', e));
   }
   process.exitCode = code;
-  return { errs: [...new Set(errs)], gl };
+  return { errs: [...new Set(errs)], gl, ok: code === 0 };
 }

--- a/tools/serve.mjs
+++ b/tools/serve.mjs
@@ -13,9 +13,13 @@ const TYPES = { '.html': 'text/html; charset=utf-8', '.js': 'text/javascript',
                 '.png': 'image/png', '.jpg': 'image/jpeg', '.webp': 'image/webp' };
 
 http.createServer((rq, rs) => {
-  const rel = decodeURI(rq.url.split('?')[0]);
-  const f = path.join(ROOT, rel === '/' ? 'index.html' : rel);
-  if (!f.startsWith(ROOT)) { rs.writeHead(403); return rs.end(); }
+  let rel;
+  try { rel = decodeURIComponent(rq.url.split('?')[0]); }
+  catch (_) { rs.writeHead(400); return rs.end('bad request'); }
+  const f = path.resolve(ROOT, '.' + (rel === '/' ? '/index.html' : rel));
+  if (f !== ROOT && !f.startsWith(ROOT + path.sep)) {
+    rs.writeHead(403); return rs.end();
+  }
   fs.readFile(f, (e, d) => {
     if (e) { rs.writeHead(404, { 'content-type': 'text/plain' }); return rs.end('not found'); }
     rs.writeHead(200, { 'content-type': TYPES[path.extname(f)] || 'application/octet-stream',


### PR DESCRIPTION
## Summary

- Add Jungle and Forest scenario selection with loading progress and pause navigation.
- Add an in-game FPS, CPU, and GPU frame-load HUD plus visible 1-5 teleport controls.
- Improve water, atmosphere, terrain, vegetation, ruins, and audio scoring.
- Add scenario tests and update the browser and audio tooling.

## Validation

- `node tools/check.mjs`
- `npm test`
- Browser smoke test covering the scenario menu, Jungle boot, teleport button and keyboard shortcut, and Esc pause/resume.
