### PR TITLE
Add collapsible performance debug overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Playwright. The game itself does not need it.
 | Shift | Sprint |
 | Space | Jump |
 | 1 - 5 | Teleport along the trail |
+| F3 | Expand or collapse the debug overlay |
 
 The teleport keys are 1 trailhead, 2 mid trail, 3 ruins approach, 4 temple
 clearing, 5 the falls.

--- a/index.html
+++ b/index.html
@@ -7,14 +7,104 @@
 <style>
   :root { color-scheme: dark; }
   html, body { margin: 0; height: 100%; overflow: hidden; background: #05070a; }
-  /* The canvas is the entire experience — no HUD, no overlay, nothing that
-     would remind you it is a program. */
   #view { display: block; width: 100vw; height: 100vh; }
   #boot {
     position: fixed; inset: 0; display: grid; place-items: center;
     font: 300 13px/1.7 ui-sans-serif, system-ui, sans-serif;
     letter-spacing: .22em; text-transform: uppercase; color: #6d7a63;
     background: #05070a; pointer-events: none;
+  }
+  .debug-overlay {
+    position: fixed;
+    z-index: 10;
+    top: max(12px, env(safe-area-inset-top));
+    right: max(12px, env(safe-area-inset-right));
+    width: min(330px, calc(100vw - 24px));
+    color: #d8e4d1;
+    border: 1px solid rgba(184, 215, 171, .2);
+    border-radius: 10px;
+    background: rgba(7, 12, 9, .86);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, .35);
+    backdrop-filter: blur(14px) saturate(.8);
+    font: 500 11px/1.35 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    overflow: hidden;
+    user-select: none;
+  }
+  .debug-overlay__header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    min-height: 40px;
+    padding: 0 12px;
+    color: inherit;
+    border: 0;
+    background: rgba(149, 190, 133, .07);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .debug-overlay__header:hover { background: rgba(149, 190, 133, .13); }
+  .debug-overlay__header:focus-visible {
+    outline: 2px solid #9ac68a;
+    outline-offset: -2px;
+  }
+  .debug-overlay__title {
+    color: #a9d398;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+  }
+  .debug-overlay__summary {
+    color: #f0f6ed;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .debug-overlay__chevron {
+    width: 16px;
+    color: #82927d;
+    font-size: 16px;
+    line-height: 1;
+    text-align: center;
+  }
+  .debug-overlay__body { padding: 3px 12px 10px; }
+  .debug-overlay__section {
+    padding: 9px 0 5px;
+    border-top: 1px solid rgba(184, 215, 171, .1);
+  }
+  .debug-overlay__section:first-child { border-top: 0; }
+  .debug-overlay__section h2 {
+    margin: 0 0 6px;
+    color: #70806b;
+    font: inherit;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+  }
+  .debug-overlay__row {
+    display: grid;
+    grid-template-columns: 88px minmax(0, 1fr);
+    gap: 10px;
+    padding: 2px 0;
+  }
+  .debug-overlay__row > span { color: #869381; }
+  .debug-overlay__row output {
+    min-width: 0;
+    color: #d8e4d1;
+    overflow: hidden;
+    text-align: right;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .debug-overlay.is-collapsed { width: 148px; }
+  .debug-overlay.is-collapsed .debug-overlay__body { display: none; }
+  @media (max-width: 520px) {
+    .debug-overlay { top: 8px; right: 8px; width: calc(100vw - 16px); }
+    .debug-overlay.is-collapsed { width: 148px; }
   }
 </style>
 <script type="importmap">

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,187 @@
+const formatCount = (value) => {
+  if (!Number.isFinite(value)) return '—';
+  if (value >= 1e6) return `${(value / 1e6).toFixed(2)}m`;
+  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}k`;
+  return String(value);
+};
+
+const browserName = () => {
+  const ua = navigator.userAgent;
+  if (/Edg\//.test(ua)) return 'Edge';
+  if (/Firefox\//.test(ua)) return 'Firefox';
+  if (/Chrome\//.test(ua)) return 'Chrome';
+  if (/Safari\//.test(ua)) return 'Safari';
+  return 'Unknown browser';
+};
+
+const platformName = () => {
+  const platform = navigator.userAgentData?.platform || navigator.platform || 'Unknown';
+  const mobile = navigator.userAgentData?.mobile ? ' mobile' : '';
+  return `${platform}${mobile}`;
+};
+
+function gpuDetails(renderer) {
+  const gl = renderer.getContext();
+  const debug = gl.getExtension('WEBGL_debug_renderer_info');
+  return {
+    renderer: debug
+      ? gl.getParameter(debug.UNMASKED_RENDERER_WEBGL)
+      : gl.getParameter(gl.RENDERER),
+    vendor: debug
+      ? gl.getParameter(debug.UNMASKED_VENDOR_WEBGL)
+      : gl.getParameter(gl.VENDOR),
+    webgl: gl.getParameter(gl.VERSION),
+    maxTexture: gl.getParameter(gl.MAX_TEXTURE_SIZE),
+  };
+}
+
+export class DebugOverlay {
+  constructor(game) {
+    this.game = game;
+    this.expanded = true;
+    this.rows = new Map();
+    this.gpu = gpuDetails(game.renderer);
+
+    this.root = document.createElement('aside');
+    this.root.id = 'debug-overlay';
+    this.root.className = 'debug-overlay';
+    this.root.setAttribute('aria-label', 'Performance debug overlay');
+
+    const header = document.createElement('button');
+    header.className = 'debug-overlay__header';
+    header.type = 'button';
+    header.setAttribute('aria-expanded', 'true');
+    header.title = 'Collapse debug overlay (F3)';
+
+    const title = document.createElement('span');
+    title.className = 'debug-overlay__title';
+    title.textContent = 'Debug';
+
+    this.summary = document.createElement('span');
+    this.summary.className = 'debug-overlay__summary';
+
+    this.chevron = document.createElement('span');
+    this.chevron.className = 'debug-overlay__chevron';
+    this.chevron.setAttribute('aria-hidden', 'true');
+    this.chevron.textContent = '−';
+
+    header.append(title, this.summary, this.chevron);
+
+    this.body = document.createElement('div');
+    this.body.className = 'debug-overlay__body';
+    this.addSection('Performance', [
+      ['fps', 'FPS'],
+      ['frame', 'CPU frame'],
+      ['draws', 'Scene draws'],
+      ['triangles', 'Triangles'],
+    ]);
+    this.addSection('Renderer', [
+      ['tier', 'Quality'],
+      ['resolution', 'Resolution'],
+      ['resources', 'GPU resources'],
+      ['gpu', 'GPU'],
+      ['graphics', 'Graphics API'],
+    ]);
+    this.addSection('System', [
+      ['platform', 'Platform'],
+      ['browser', 'Browser'],
+      ['hardware', 'Hardware'],
+    ]);
+
+    this.root.append(header, this.body);
+    document.body.append(this.root);
+
+    this._toggle = () => this.setExpanded(!this.expanded);
+    this._key = (event) => {
+      if (event.code !== 'F3') return;
+      event.preventDefault();
+      this._toggle();
+    };
+    header.addEventListener('click', this._toggle);
+    window.addEventListener('keydown', this._key);
+    this.header = header;
+
+    this.update();
+    this._timer = window.setInterval(() => this.update(), 250);
+  }
+
+  addSection(title, rows) {
+    const section = document.createElement('section');
+    section.className = 'debug-overlay__section';
+
+    const heading = document.createElement('h2');
+    heading.textContent = title;
+    section.append(heading);
+
+    for (const [key, label] of rows) {
+      const row = document.createElement('div');
+      row.className = 'debug-overlay__row';
+      const name = document.createElement('span');
+      name.textContent = label;
+      const value = document.createElement('output');
+      value.textContent = '—';
+      row.append(name, value);
+      section.append(row);
+      this.rows.set(key, value);
+    }
+    this.body.append(section);
+  }
+
+  setExpanded(expanded) {
+    this.expanded = expanded;
+    this.root.classList.toggle('is-collapsed', !expanded);
+    this.header.setAttribute('aria-expanded', String(expanded));
+    this.header.title = `${expanded ? 'Collapse' : 'Expand'} debug overlay (F3)`;
+    this.chevron.textContent = expanded ? '−' : '+';
+  }
+
+  set(key, value, title = '') {
+    const row = this.rows.get(key);
+    if (!row) return;
+    row.textContent = value;
+    row.title = title || value;
+  }
+
+  update() {
+    const { game } = this;
+    const info = game.info();
+    const renderer = game.renderer;
+    const canvas = renderer.domElement;
+    const fps = game.fps || 0;
+
+    this.summary.textContent = `${fps.toFixed(0)} FPS`;
+    this.set('fps', fps ? fps.toFixed(1) : '—');
+    this.set('frame', game.frameMs ? `${game.frameMs.toFixed(2)} ms` : '—');
+    this.set('draws', formatCount(info.calls));
+    this.set('triangles', formatCount(info.triangles), `${info.triangles.toLocaleString()} triangles`);
+    this.set('tier', `${game.tier} · ${game.frameCap} fps cap`);
+    this.set(
+      'resolution',
+      `${canvas.width} × ${canvas.height} · ${renderer.getPixelRatio().toFixed(2)} dpr`,
+    );
+    this.set(
+      'resources',
+      `${info.geometries} geo · ${info.textures} tex · ${info.programs} programs`,
+    );
+    this.set('gpu', this.gpu.renderer, `${this.gpu.vendor} · ${this.gpu.renderer}`);
+    this.set(
+      'graphics',
+      `${this.gpu.webgl.replace('WebGL ', '')} · ${this.gpu.maxTexture}px max texture`,
+    );
+    this.set('platform', platformName());
+    this.set('browser', browserName(), navigator.userAgent);
+
+    const cores = navigator.hardwareConcurrency
+      ? `${navigator.hardwareConcurrency} logical cores`
+      : 'core count unavailable';
+    const memory = navigator.deviceMemory ? ` · ${navigator.deviceMemory} GB memory` : '';
+    this.set('hardware', cores + memory);
+  }
+
+  dispose() {
+    clearInterval(this._timer);
+    window.removeEventListener('keydown', this._key);
+    this.header.removeEventListener('click', this._toggle);
+    this.root.remove();
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ import { buildWorldField } from './render/field.js';
 import { Canopy, patchCanopyLight } from './render/canopy.js';
 import { Atmosphere } from './render/atmosphere.js';
 import { Ambience } from './audio/engine.js';
+import { DebugOverlay } from './debug.js';
 
 /* Quality tiers.
  *
@@ -46,6 +47,7 @@ class Game {
     this.paused = false;
     this.running = false;
     this.fps = 0;
+    this.frameMs = 0;
     this._acc = 0;
     this._frames = 0;
     this._fpsT = 0;
@@ -508,8 +510,11 @@ class Game {
       const step = this._acc;
       this._acc = 0;
 
+      const frameStart = performance.now();
       this.step(step);
       this.render();
+      const frameMs = performance.now() - frameStart;
+      this.frameMs += (frameMs - this.frameMs) * (this.frameMs ? 0.12 : 1);
 
       this._frames++;
       this._fpsT += step;
@@ -611,6 +616,7 @@ class Game {
     this.body.dispose();
     this.atmos?.dispose();
     this.canopy?.dispose();
+    this.debug?.dispose();
     this.renderer.dispose();
   }
 }
@@ -620,6 +626,7 @@ const _size = new THREE.Vector2();
 const game = new Game(document.getElementById('view'));
 window.__game = game;
 window.THREE = THREE;
+game.debug = new DebugOverlay(game);
 
 /* Recording convenience: number keys jump to the authored viewpoints.
  *


### PR DESCRIPTION
## Summary

- add a clean, responsive debug window over the game canvas
- report FPS, CPU frame time, scene draw calls, triangle count, renderer resources, quality tier, resolution, GPU/WebGL details, platform, browser, and available hardware details
- allow the panel to collapse from its header or with F3
- document the F3 control in the README

## Implementation

The overlay is a lightweight DOM component that samples existing Three.js renderer counters every 250 ms. The game loop records a smoothed CPU frame duration without adding GPU synchronization or changing the render pipeline. GPU details use `WEBGL_debug_renderer_info` when available and fall back to standard WebGL vendor/renderer values.

## Validation

- verified the expanded overlay populates live renderer and platform values
- verified the collapsed panel state and responsive sizing
- confirmed all JavaScript sources parse successfully